### PR TITLE
feat: align palette groups and translate UI to English

### DIFF
--- a/docs_pallete_maker/project/frontend/frontend-docs.md
+++ b/docs_pallete_maker/project/frontend/frontend-docs.md
@@ -35,11 +35,16 @@ UI changes should start by updating the active feature folder before touching pr
 The picker grid displays all 51 colors of the fixed palette:
 
 - order: 3 achromatics → 12 Brights → 12 Pastels → 12 Desaturated → 12 Darks
+- within each chromatic group, the hue order mirrors the bright palette
+  sequence exactly: Scarlet → Vermillion → Tangerine → Amber → Canary →
+  Chartreuse → Emerald → Teal → Cobalt → Indigo → Violet → Fuchsia
 - each swatch is a `<button>` element (88px, `--swatch-outer` CSS var) showing a color circle, name, and HEX
 - dimmed (incompatible) cards carry `aria-disabled="true"` and `tabindex="-1"`
 - responsive columns: 3 (mobile ≥375) → 4 (≥480) → 6 (≥640) → 8 (≥1024) → 10 (≥1280)
 - color selection state is ephemeral (no persistence)
 - DOM refs are cached on init in a `DOM` object; full grid rebuild on each state change
+- the achromatic White swatch uses `#FFFFFF` with a subtle neutral inner outline
+  so it remains visible against the white page background
 
 ## PM Harmony Algorithm
 
@@ -52,11 +57,26 @@ Lives in `src/scripts/harmony.mjs`. Compatibility is determined by two attribute
 
 **Why soft temperature:** under a strict temperature filter, cool-side bases access at most 5–6 Itten hues. Dropping the filter gives ≥12 hues per base while the warm/cool aesthetic is preserved via visual grouping.
 
-**Achromatics** (Black `#1C1C1C`, Gray `#8C8C8C`, White `#F0F0F0`) are compatible with all 51 colors.
+**Achromatics** (Black `#1C1C1C`, Gray `#8C8C8C`, White `#FFFFFF`) are compatible with all 51 colors.
 
-**Limits:** MAX_CHROMATIC = 11, MAX_TOTAL = 14, download enabled from 1 color.
+**Limits:** MAX_CHROMATIC = 12, MAX_TOTAL = 15, download enabled from 1 color.
 
 **Base color:** first non-achromatic added; determines the compatibility filter. On removal of the base, the next remaining non-achromatic becomes the new base (Variant A).
+
+### Group Alignment
+
+All non-bright chromatic groups are aligned slot-for-slot with the bright
+palette:
+
+- **Pastels** use a lighter 12-slot sequence:
+  Blush, Nectarine, Beige, Off-White, Primrose, Pistachio, Mint, Aqua, Sky,
+  Periwinkle, Lavender, Orchid
+- **Desaturated** use a muted 12-slot sequence:
+  Brick, Coral, Terracotta, Sand, Straw, Sage, Fern, Dusty Teal, Slate,
+  Dusty Indigo, Mauve, Antique Rose
+- **Darks** use a darker 12-slot sequence:
+  Burgundy, Rust, Burnt Orange, Ochre, Olive Gold, Olive, Forest, Pine, Navy,
+  Midnight, Plum, Mulberry
 
 ## Final Palette Sectioning
 
@@ -76,8 +96,14 @@ PNG export uses html2canvas (CDN, SRI-protected):
 
 - an offscreen detached stage is built per-call with `buildColorSwatch` using export-size opts (130px circles)
 - `document.fonts.ready` is awaited before capture to ensure Inter font is loaded
-- export button shows loading state ("Экспорт...") during render; restored in `.finally()`
+- export button shows loading state ("Exporting...") during render; restored in `.finally()`
 - `.catch()` handles failures silently; button re-enables regardless
+
+## UI Language
+
+- runtime UI copy is English (`Reset`, `Download PNG`, `Your Palette`, English
+  drawer toggle labels, English helper text in the header)
+- color names remain English palette labels in both the grid and exported PNG
 
 ## Accessibility
 

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="ru">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="theme-color" content="#ffffff" />
@@ -276,8 +276,8 @@
           <p
             class="text-gray-400 mt-2 md:mt-3 text-[11px] md:text-sm font-medium leading-tight"
           >
-            1. Выберите базовый цвет → 2. Добавьте совместимые → 3. Скачайте
-            палитру
+            1. Pick a base color → 2. Add matching colors → 3. Download your
+            palette
           </p>
         </div>
         <div class="flex gap-2 w-full md:w-auto">
@@ -286,7 +286,7 @@
             id="resetBtn"
             class="flex-1 md:flex-none px-4 py-2 border border-gray-300 text-[10px] font-black uppercase"
           >
-            Сброс
+            Reset
           </button>
           <button
             type="button"
@@ -294,7 +294,7 @@
             disabled
             class="flex-1 md:flex-none px-6 py-2 bg-black text-white text-[10px] font-black uppercase tracking-widest"
           >
-            Скачать PNG
+            Download PNG
           </button>
         </div>
       </div>
@@ -310,7 +310,7 @@
         id="toggleBtn"
         aria-expanded="true"
         aria-controls="userPalette"
-        aria-label="Свернуть палитру"
+        aria-label="Collapse palette"
       >
         <span id="arrow" class="text-[10px] font-bold">&#x2228;</span>
       </button>
@@ -319,7 +319,7 @@
           <h3
             class="text-[9px] font-black uppercase tracking-[0.2em] text-gray-400"
           >
-            Ваша палитра (<span id="count" aria-live="polite">0</span>/14)
+            Your Palette (<span id="count" aria-live="polite">0</span>/15)
           </h3>
         </div>
         <div id="userPalette"></div>
@@ -356,6 +356,19 @@
         arrow: document.getElementById("arrow"),
       };
 
+      const TRUE_WHITE_HEX = "#FFFFFF";
+      const WHITE_SWATCH_OUTLINE = "#d9d9d9";
+
+      function isPureWhite(color) {
+        return color.hex.toUpperCase() === TRUE_WHITE_HEX;
+      }
+
+      function getSwatchInnerBorder(borderWidth, color) {
+        return `${borderWidth} solid ${
+          isPureWhite(color) ? WHITE_SWATCH_OUTLINE : "#FFFFFF"
+        }`;
+      }
+
       // ── Interaction ───────────────────────────────────────────────
       function handleClick(color) {
         if (isSelected(userPalette, color)) {
@@ -376,7 +389,7 @@
        * @param {{
        *   outerSize: string,
        *   innerSize: string,
-       *   innerBorder: string,
+       *   innerBorderWidth: string,
        *   borderStyle: string,
        *   boxShadow: string,
        *   nameFontSize: string,
@@ -411,7 +424,7 @@
           ";height:" +
           opts.innerSize +
           ";border-radius:50%;border:" +
-          opts.innerBorder +
+          getSwatchInnerBorder(opts.innerBorderWidth, color) +
           ";background-color:" +
           color.hex +
           ";";
@@ -473,6 +486,7 @@
           const inner = document.createElement("div");
           inner.className = "color-inner";
           inner.style.backgroundColor = color.hex;
+          inner.style.border = getSwatchInnerBorder("3px", color);
           wrapper.appendChild(inner);
 
           const nameEl = document.createElement("div");
@@ -497,7 +511,7 @@
         const swatch = buildColorSwatch(color, {
           outerSize: "46px",
           innerSize: "36px",
-          innerBorder: "2px solid white",
+          innerBorderWidth: "2px",
           borderStyle: "1.5px solid " + (isBase ? "#4a4a4a" : "#c4c4c4"),
           boxShadow: "0 0 0 " + (isBase ? "2.5px #4a4a4a" : "1.5px #c4c4c4"),
           nameFontSize: "7px",
@@ -575,7 +589,7 @@
         DOM.toggleBtn.setAttribute("aria-expanded", String(!isClosed));
         DOM.toggleBtn.setAttribute(
           "aria-label",
-          isClosed ? "Развернуть палитру" : "Свернуть палитру",
+          isClosed ? "Expand palette" : "Collapse palette",
         );
         updateDrawerSpace();
       }
@@ -592,7 +606,7 @@
 
         const btn = DOM.downloadBtn;
         btn.disabled = true;
-        btn.textContent = "Экспорт...";
+        btn.textContent = "Exporting...";
 
         // PNG export safety: build the render subtree in a fresh detached
         // node per call, attach offscreen, render, then remove. No persistent
@@ -625,7 +639,7 @@
             const swatch = buildColorSwatch(color, {
               outerSize: "130px",
               innerSize: "115px",
-              innerBorder: "4px solid white",
+              innerBorderWidth: "4px",
               borderStyle: "2px solid #e5e5e5",
               boxShadow: "",
               nameFontSize: "14px",
@@ -670,7 +684,7 @@
               .finally(() => {
                 stage.remove();
                 btn.disabled = userPalette.length === 0;
-                btn.textContent = "Скачать PNG";
+                btn.textContent = "Download PNG";
               });
           });
         }, 50);

--- a/specs/004-palette-alignment/plan.md
+++ b/specs/004-palette-alignment/plan.md
@@ -1,0 +1,21 @@
+# 004 — Implementation Plan
+
+## Approach
+
+Keep the architecture unchanged and solve the task in four focused layers:
+
+1. **Palette data** — update `PM_PALETTE`, limits, hue ordering, and white swatch semantics in `src/scripts/harmony.mjs`
+2. **Runtime UI** — translate visible strings and ensure white swatches stay legible in `index.html`
+3. **Verification** — expand unit tests so ordering, counts, and white behavior are asserted in code
+4. **Docs** — sync frontend docs with the new ordering contract and English UI
+
+## Risks
+
+- Pastel hue alignment is partly aesthetic, so the updated color choices should stay close to the user's described mapping rather than blindly preserving existing names
+- Pure white can disappear on a white background if the swatch outline logic is not shared between grid, drawer, and export
+- Reordering chromatic groups may subtly change warm/cool section membership, so tests should pin the intended mapping
+
+## Verification
+
+- `pnpm run ci`
+- Manual smoke check in preview PR: white swatch visibility, 15-item counter, aligned hue order, English copy

--- a/specs/004-palette-alignment/spec.md
+++ b/specs/004-palette-alignment/spec.md
@@ -1,0 +1,85 @@
+# 004 — Palette Alignment And English UI
+
+## Status
+
+Active
+
+## Goal
+
+Bring all saturation groups into the same hue-order as the bright palette,
+raise the chromatic selection cap to 12, fix the white swatch so it renders as
+true white, and translate the runtime interface to English.
+
+## Scope
+
+- Increase palette limits from 11 chromatic / 14 total to 12 chromatic / 15 total
+- Make achromatic White render as pure white in the picker, drawer, and export
+- Reorder desaturated and dark groups so their 12 hues align one-to-one with the bright palette
+- Rebuild the pastel lineup so its hue progression also aligns with the bright palette
+- Translate visible UI copy and accessibility labels from Russian to English
+
+## Non-goals
+
+- No persistence or save/load behavior
+- No framework migration
+- No new export format beyond PNG
+
+## Data Rules
+
+The canonical hue order remains defined by the bright palette:
+
+1. Scarlet
+2. Vermillion
+3. Tangerine
+4. Amber
+5. Canary
+6. Chartreuse
+7. Emerald
+8. Teal
+9. Cobalt
+10. Indigo
+11. Violet
+12. Fuchsia
+
+Every other chromatic group must follow this same 12-slot order.
+
+### Pastels
+
+Pastels should remain lighter counterparts of the bright palette. The revised
+warm side should map as:
+
+1. Blush → Scarlet
+2. a new pastel between Peach and Apricot → Vermillion
+3. Beige → Tangerine
+4. Off-White → Amber
+5. Primrose → Canary
+6. a light chartreuse counterpart → Chartreuse
+
+The cool half should continue the same aligned order through the green → teal →
+blue → indigo → violet → fuchsia range.
+
+### White Swatch
+
+Achromatic White must use a true white fill (`#FFFFFF`) while still remaining
+visible against the white page background via a subtle neutral outline.
+
+## Limits
+
+| Parameter     | Value |
+| ------------- | ----- |
+| MAX_CHROMATIC | 12    |
+| MAX_TOTAL     | 15    |
+| MIN_TO_EXPORT | 1     |
+
+## Acceptance Criteria
+
+- [ ] The app still renders 51 swatches total
+- [ ] White is pure white, not light gray, in the picker, drawer, and export
+- [ ] The bright palette order remains unchanged
+- [ ] The pastel palette follows the same 12-slot hue order as the bright palette
+- [ ] The desaturated palette follows the same 12-slot hue order as the bright palette
+- [ ] The dark palette follows the same 12-slot hue order as the bright palette
+- [ ] The user can select up to 12 chromatic colors plus up to 3 achromatics
+- [ ] The drawer counter and disabled states reflect the new 15-color total cap
+- [ ] All user-facing UI copy is English
+- [ ] `pnpm run ci` is green

--- a/specs/004-palette-alignment/tasks.md
+++ b/specs/004-palette-alignment/tasks.md
@@ -1,0 +1,21 @@
+# 004 — Tasks
+
+## Implementation
+
+- [x] Raise `MAX_CHROMATIC` to 12 and `MAX_TOTAL` to 15
+- [x] Fix achromatic White so it renders as true white with a subtle visible outline
+- [x] Align pastel hue order with the bright palette, including the revised warm-side mapping
+- [x] Align desaturated hue order with the bright palette
+- [x] Align dark hue order with the bright palette
+- [x] Translate visible UI copy and relevant aria labels to English
+
+## Tests
+
+- [x] Update harmony unit tests for the new limits
+- [x] Add tests for aligned group ordering
+- [x] Keep `pnpm run ci` green
+
+## Docs
+
+- [x] Update `docs_pallete_maker/project/frontend/frontend-docs.md`
+- [ ] Open a PR with verification notes

--- a/specs/004-palette-alignment/tasks.md
+++ b/specs/004-palette-alignment/tasks.md
@@ -18,4 +18,4 @@
 ## Docs
 
 - [x] Update `docs_pallete_maker/project/frontend/frontend-docs.md`
-- [ ] Open a PR with verification notes
+- [x] Open a PR with verification notes

--- a/src/scripts/harmony.mjs
+++ b/src/scripts/harmony.mjs
@@ -10,7 +10,7 @@ export const PM_PALETTE = [
   // Achromatics (3) — compatible with all 51
   { hex: "#1C1C1C", name: "Black", isAchromatic: true },
   { hex: "#8C8C8C", name: "Gray", isAchromatic: true },
-  { hex: "#F0F0F0", name: "White", isAchromatic: true },
+  { hex: "#FFFFFF", name: "White", isAchromatic: true },
   // Brights warm (6)
   { hex: "#E82535", name: "Scarlet", group: "bright", temp: "warm" },
   { hex: "#E84B20", name: "Vermillion", group: "bright", temp: "warm" },
@@ -25,52 +25,52 @@ export const PM_PALETTE = [
   { hex: "#3828E8", name: "Indigo", group: "bright", temp: "cool" },
   { hex: "#8820E8", name: "Violet", group: "bright", temp: "cool" },
   { hex: "#D020AA", name: "Fuchsia", group: "bright", temp: "cool" },
-  // Pastels warm (7)
+  // Pastels warm (6) — aligned to the bright hue order
   { hex: "#F5B5BB", name: "Blush", group: "pastel", temp: "warm" },
-  { hex: "#F5C5B0", name: "Peach", group: "pastel", temp: "warm" },
-  { hex: "#F5D5B0", name: "Apricot", group: "pastel", temp: "warm" },
+  { hex: "#F5CDB0", name: "Nectarine", group: "pastel", temp: "warm" },
   { hex: "#E8D5B5", name: "Beige", group: "pastel", temp: "warm" },
-  { hex: "#FAF0E6", name: "Off-white", group: "pastel", temp: "warm" },
+  { hex: "#FAF0E6", name: "Off-White", group: "pastel", temp: "warm" },
   { hex: "#F7EDA5", name: "Primrose", group: "pastel", temp: "warm" },
-  { hex: "#EEB8E5", name: "Orchid", group: "pastel", temp: "warm" },
-  // Pastels cool (5)
+  { hex: "#D8EEB0", name: "Pistachio", group: "pastel", temp: "warm" },
+  // Pastels cool (6)
   { hex: "#B0EEC5", name: "Mint", group: "pastel", temp: "cool" },
   { hex: "#B0EEDE", name: "Aqua", group: "pastel", temp: "cool" },
   { hex: "#B0CDEE", name: "Sky", group: "pastel", temp: "cool" },
   { hex: "#C0B8EE", name: "Periwinkle", group: "pastel", temp: "cool" },
   { hex: "#DCB8EE", name: "Lavender", group: "pastel", temp: "cool" },
-  // Desaturated warm (7)
+  { hex: "#EEB8E5", name: "Orchid", group: "pastel", temp: "cool" },
+  // Desaturated warm (6) — aligned to the bright hue order
   { hex: "#B86068", name: "Brick", group: "desaturated", temp: "warm" },
   { hex: "#C07860", name: "Coral", group: "desaturated", temp: "warm" },
   { hex: "#C08A65", name: "Terracotta", group: "desaturated", temp: "warm" },
   { hex: "#C0A268", name: "Sand", group: "desaturated", temp: "warm" },
   { hex: "#B8B268", name: "Straw", group: "desaturated", temp: "warm" },
   { hex: "#88A865", name: "Sage", group: "desaturated", temp: "warm" },
-  { hex: "#B860A2", name: "Antique Rose", group: "desaturated", temp: "warm" },
-  // Desaturated cool (5)
+  // Desaturated cool (6)
   { hex: "#60A878", name: "Fern", group: "desaturated", temp: "cool" },
   { hex: "#50A095", name: "Dusty Teal", group: "desaturated", temp: "cool" },
   { hex: "#5082B8", name: "Slate", group: "desaturated", temp: "cool" },
   { hex: "#6860B8", name: "Dusty Indigo", group: "desaturated", temp: "cool" },
   { hex: "#9860B8", name: "Mauve", group: "desaturated", temp: "cool" },
-  // Darks warm (7)
+  { hex: "#B860A2", name: "Antique Rose", group: "desaturated", temp: "cool" },
+  // Darks warm (6) — aligned to the bright hue order
   { hex: "#8C1820", name: "Burgundy", group: "dark", temp: "warm" },
   { hex: "#8C3015", name: "Rust", group: "dark", temp: "warm" },
   { hex: "#8C5018", name: "Burnt Orange", group: "dark", temp: "warm" },
   { hex: "#8C6C15", name: "Ochre", group: "dark", temp: "warm" },
   { hex: "#787815", name: "Olive Gold", group: "dark", temp: "warm" },
   { hex: "#4A7A18", name: "Olive", group: "dark", temp: "warm" },
-  { hex: "#781860", name: "Mulberry", group: "dark", temp: "warm" },
-  // Darks cool (5)
+  // Darks cool (6)
   { hex: "#187838", name: "Forest", group: "dark", temp: "cool" },
   { hex: "#187870", name: "Pine", group: "dark", temp: "cool" },
   { hex: "#182878", name: "Navy", group: "dark", temp: "cool" },
   { hex: "#201878", name: "Midnight", group: "dark", temp: "cool" },
   { hex: "#5A1878", name: "Plum", group: "dark", temp: "cool" },
+  { hex: "#781860", name: "Mulberry", group: "dark", temp: "cool" },
 ];
 
-export const MAX_TOTAL = 14;
-export const MAX_CHROMATIC = 11;
+export const MAX_TOTAL = 15;
+export const MAX_CHROMATIC = 12;
 
 /** Lookup map for O(1) palette-order sort (used in getGrouped). */
 export const PM_INDEX = new Map(PM_PALETTE.map((c, i) => [c.hex, i]));

--- a/tests/harmony.test.mjs
+++ b/tests/harmony.test.mjs
@@ -35,6 +35,66 @@ const BURGUNDY = PM_PALETTE.find((c) => c.name === "Burgundy"); // dark warm
 const FERN = PM_PALETTE.find((c) => c.name === "Fern"); // desaturated cool
 const FOREST = PM_PALETTE.find((c) => c.name === "Forest"); // dark cool
 
+const BRIGHT_ORDER = [
+  "Scarlet",
+  "Vermillion",
+  "Tangerine",
+  "Amber",
+  "Canary",
+  "Chartreuse",
+  "Emerald",
+  "Teal",
+  "Cobalt",
+  "Indigo",
+  "Violet",
+  "Fuchsia",
+];
+
+const PASTEL_ORDER = [
+  "Blush",
+  "Nectarine",
+  "Beige",
+  "Off-White",
+  "Primrose",
+  "Pistachio",
+  "Mint",
+  "Aqua",
+  "Sky",
+  "Periwinkle",
+  "Lavender",
+  "Orchid",
+];
+
+const DESATURATED_ORDER = [
+  "Brick",
+  "Coral",
+  "Terracotta",
+  "Sand",
+  "Straw",
+  "Sage",
+  "Fern",
+  "Dusty Teal",
+  "Slate",
+  "Dusty Indigo",
+  "Mauve",
+  "Antique Rose",
+];
+
+const DARK_ORDER = [
+  "Burgundy",
+  "Rust",
+  "Burnt Orange",
+  "Ochre",
+  "Olive Gold",
+  "Olive",
+  "Forest",
+  "Pine",
+  "Navy",
+  "Midnight",
+  "Plum",
+  "Mulberry",
+];
+
 // ── PM_PALETTE sanity ─────────────────────────────────────────────────────────
 
 describe("PM_PALETTE", () => {
@@ -45,6 +105,10 @@ describe("PM_PALETTE", () => {
   it("contains exactly 3 achromatics", () => {
     const achros = PM_PALETTE.filter((c) => c.isAchromatic);
     assert.equal(achros.length, 3);
+  });
+
+  it("uses a true white achromatic swatch", () => {
+    assert.equal(WHITE.hex, "#FFFFFF");
   });
 
   it("PM_INDEX covers every entry", () => {
@@ -60,6 +124,21 @@ describe("PM_PALETTE", () => {
       assert.ok(c.group, `${c.name} missing group`);
       assert.ok(c.temp === "warm" || c.temp === "cool", `${c.name} bad temp`);
     });
+  });
+
+  it("keeps every chromatic group aligned to the bright hue order", () => {
+    const namesForGroup = (group) =>
+      PM_PALETTE.filter((c) => c.group === group).map((c) => c.name);
+
+    assert.deepEqual(namesForGroup("bright"), BRIGHT_ORDER);
+    assert.deepEqual(namesForGroup("pastel"), PASTEL_ORDER);
+    assert.deepEqual(namesForGroup("desaturated"), DESATURATED_ORDER);
+    assert.deepEqual(namesForGroup("dark"), DARK_ORDER);
+  });
+
+  it("uses the updated selection limits", () => {
+    assert.equal(MAX_CHROMATIC, 12);
+    assert.equal(MAX_TOTAL, 15);
   });
 });
 
@@ -187,8 +266,11 @@ describe("isDimmed", () => {
   });
 
   it("dims any unselected color when total limit is reached", () => {
-    // Build a full 14-color palette: 3 achromatics + 11 chroms of same group
-    const brights = PM_PALETTE.filter((c) => c.group === "bright").slice(0, 11);
+    // Build a full 15-color palette: 3 achromatics + 12 chroms of same group
+    const brights = PM_PALETTE.filter((c) => c.group === "bright").slice(
+      0,
+      MAX_CHROMATIC,
+    );
     const full = [BLACK, GRAY, WHITE, ...brights];
     assert.equal(full.length, MAX_TOTAL);
 


### PR DESCRIPTION
## Summary

- Raise selection limits to 12 chromatic + 3 achromatic = 15 total
- Fix White swatch to render as `#FFFFFF` with a visible `#d9d9d9` inner border
- Realign pastel / desaturated / dark hue order 1-to-1 with the bright palette
- Add Nectarine (pastel Vermillion) and shift the warm-pastel lineup accordingly
- Translate all visible UI copy and aria-labels to English

## Test plan

- [ ] `pnpm run ci` green (38/38 tests, build, format, html-validate)
- [ ] White swatch is pure white with visible gray outline in picker, drawer, and PNG export
- [ ] Counter shows `/15`; 12 chromatics can be selected before the cap triggers
- [ ] All four chromatic groups follow Scarlet → … → Fuchsia hue order
- [ ] All UI copy is English (header, buttons, drawer labels, aria-labels)

🤖 Generated with [Claude Code](https://claude.com/claude-code)