### PR TITLE
feat: local Claude runner for AI review via self-hosted macOS runner

### DIFF
--- a/.github/claude/prompts/pr-review.md
+++ b/.github/claude/prompts/pr-review.md
@@ -1,0 +1,26 @@
+You are the code reviewer for pallete-maker — a static HTML/CSS/JS
+colour-palette tool using chroma-js, html2canvas, and Tailwind CSS.
+
+Review the diff below. Apply these priorities in order:
+
+1. **Mobile grid reflow** — picker grid uses 3→4→6→8→10 responsive columns;
+   all 51 swatches must fit without layout breakage.
+2. **Harmony rules** — `isCompatible`, `isDimmed`, `getGrouped` logic; limits
+   `MAX_CHROMATIC=12`, `MAX_TOTAL=15`.
+3. **PNG export safety** — must use a detached offscreen stage,
+   `document.fonts.ready` before capture, `.finally()` cleanup, `.catch()` for
+   silent failure.
+4. **English-only UI copy** — zero Cyrillic in `index.html` or any `.mjs`
+   runtime file.
+5. **Test coverage** — new behaviour must be pinned by a unit test in
+   `tests/harmony.test.mjs`.
+6. **Maintainability** — no hardcoded constants that already exist in
+   `harmony.mjs`; no dead code; no stale comments.
+
+Output rules:
+- Respond in Markdown only.
+- Lead with a one-line verdict: `✅ Approve`, `⚠️ Comment`, or
+  `❌ Request changes`.
+- List only substantive findings; skip Prettier/whitespace-only issues.
+- Tag each finding with `[low]`, `[medium]`, or `[high]`.
+- If there are no findings, say so explicitly after the verdict.

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
@@ -132,13 +132,13 @@ jobs:
           github.event.pull_request.draft == false
         )
       )
-    name: AI Review
+    name: AI Review (local)
     runs-on: [self-hosted, macOS, ai-runner]
     timeout-minutes: 15
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -14,7 +14,7 @@ on:
         required: true
         type: string
       trigger_mode:
-        description: Review gate trigger mode
+        description: Review gate trigger mode (gemini/codex only; ignored for claude)
         required: false
         type: string
 
@@ -37,17 +37,19 @@ concurrency:
 
 jobs:
   ai-review:
+    # Gate-based path: gemini and codex (and unset default → gemini)
     if: >
-      github.event_name == 'workflow_dispatch' ||
       (
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.draft == false &&
+        github.event_name == 'workflow_dispatch' ||
         (
-          vars.AI_REVIEW_AGENT == '' ||
-          vars.AI_REVIEW_AGENT == 'gemini' ||
-          vars.AI_REVIEW_AGENT == 'codex' ||
-          vars.AI_REVIEW_AGENT == 'claude'
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.draft == false
         )
+      ) &&
+      (
+        vars.AI_REVIEW_AGENT == '' ||
+        vars.AI_REVIEW_AGENT == 'gemini' ||
+        vars.AI_REVIEW_AGENT == 'codex'
       )
     name: AI Review
     runs-on: ubuntu-latest
@@ -79,20 +81,12 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             trigger_mode="${{ inputs.trigger_mode || 'skip' }}"
           else
-            # None of the supported review backends accept bot-posted
-            # trigger comments on pull_request events:
-            # - Gemini Code Assist silently ignores bot-posted
-            #   /gemini review and never emits a review; the gate
-            #   times out waiting for it.
-            # - Codex Cloud replies "trigger did not come from a
-            #   connected human Codex account" and fails fast.
-            # - claude-review.yml gates on OWNER/MEMBER/COLLABORATOR
-            #   author_association, so bot-posted @claude review once
-            #   never dispatches the actual reviewer.
-            # Gate therefore stays in skip mode on every pull_request
-            # event. Gemini Code Assist's on-open auto-review covers
-            # initial PR review; manual recovery on synchronize uses
-            # pnpm run review:switch or a trusted human trigger.
+            # Gemini and Codex do not accept bot-posted trigger comments
+            # on pull_request events, so the gate stays in skip mode.
+            # Gemini Code Assist auto-reviews on PR open; manual recovery
+            # uses pnpm run review:switch or a trusted human trigger.
+            # Claude is handled by the ai-review-local job (self-hosted
+            # runner) and never reaches this gate path.
             # See docs_pallete_maker/project/devops/ai-runner.md
             # §Backend Trigger Constraints for the full matrix.
             trigger_mode="skip"
@@ -125,3 +119,42 @@ jobs:
           AI_REVIEW_WAIT_MS: "1200000"
           AI_REVIEW_POLL_MS: "15000"
         run: node scripts/ai-review-gate.mjs
+
+  ai-review-local:
+    # Local CLI path: claude via self-hosted macOS runner.
+    # Triggers automatically on every pull_request push — no trigger comment needed.
+    if: >
+      vars.AI_REVIEW_AGENT == 'claude' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.draft == false
+        )
+      )
+    name: AI Review
+    runs-on: [self-hosted, macOS, ai-runner]
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Resolve PR context
+        id: pr
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          AI_REVIEW_PR_NUMBER: ${{ inputs.pr_number }}
+        run: node scripts/resolve-pr-context.mjs
+
+      - name: Run local Claude review
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          AI_REVIEW_AGENT: claude
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          PR_BASE_REF: ${{ steps.pr.outputs.base_ref }}
+          PR_HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          CLAUDE_CLI_PATH: ${{ vars.CLAUDE_CLI_PATH }}
+        run: bash scripts/run-ai-pr-review.sh

--- a/docs_pallete_maker/project/devops/ai-runner.md
+++ b/docs_pallete_maker/project/devops/ai-runner.md
@@ -19,12 +19,13 @@ Local macOS helper scripts may also store the current selection under:
 
 ## Backend Requirements
 
-- `claude` is the default implementation agent. The user runs it from a local
-  Claude Code terminal session, and no additional GitHub secret is required
-  for the default implementation path. When `claude` is used as a third-tier
-  review backend through the `@claude` GitHub app, `ANTHROPIC_API_KEY` must be
-  configured in repository secrets.
-- `gemini` is the default review backend and runs natively on GitHub pull
+- `claude` is the default implementation agent and the preferred review backend.
+  Review runs on a self-hosted macOS runner via `claude -p` (print mode). The
+  runner must be registered with labels `self-hosted`, `macOS`, `ai-runner` and
+  the `claude` CLI must be authenticated (`claude auth`). No `ANTHROPIC_API_KEY`
+  secret is required — the CLI uses the local Max subscription session.
+  Set `CLAUDE_CLI_PATH` repository variable if the binary is not on `$PATH`.
+- `gemini` is the fallback review backend and runs natively on GitHub pull
   requests via the Gemini Code Assist GitHub App without additional setup.
 - `codex` is the optional review and implementation backend. Native Codex PR
   review needs no repository secret; Codex implementation requires the Codex
@@ -35,28 +36,28 @@ with an explanatory comment instead of silently skipping.
 
 ## Backend Trigger Constraints
 
-None of the supported review backends accept bot-posted trigger comments
-on `pull_request` events. This matrix is the single source of truth for
-why `ai-review.yml` keeps `trigger_mode=skip` on every `pull_request`
-event regardless of the selected backend.
+This matrix is the single source of truth for the trigger behaviour of
+each review backend. Gemini and Codex use the gate-based path with
+`trigger_mode=skip` on `pull_request` events. Claude uses the self-hosted
+local runner path and triggers automatically without any human comment.
 
-| Backend                                | Auto-review on `opened` / `ready_for_review` | Auto-review on `synchronize` | Accepts bot-posted trigger comment                                                                                 | Manual recovery path                                                                 |
-| -------------------------------------- | -------------------------------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
-| Gemini (`gemini-code-assist[bot]`)     | yes when the GitHub App is installed         | no                           | **no** — silently ignored, the gate times out after 20 minutes                                                     | trusted human posts `/gemini review` (responses arrive within ~2 minutes)            |
-| Codex (`chatgpt-codex-connector[bot]`) | yes (Codex Cloud auto-reviews on PR open)    | no                           | **no** — connector replies "trigger did not come from a connected human Codex account" and the gate fails fast     | trusted human posts `@codex review`, or run `pnpm run review:switch -- --to <other>` |
-| Claude (`claude[bot]`)                 | no                                           | no                           | **no** — `claude-review.yml` gates on `author_association in (OWNER, MEMBER, COLLABORATOR)` and drops bot comments | trusted human posts `@claude review once`                                            |
+| Backend                                | Auto-review on `opened` / `ready_for_review` | Auto-review on `synchronize`     | Trigger mechanism                                                                                     | Manual recovery path                                                                |
+| -------------------------------------- | -------------------------------------------- | -------------------------------- | ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| Gemini (`gemini-code-assist[bot]`)     | yes when the GitHub App is installed         | no                               | gate-based: trusted human posts `/gemini review`; bot-posted trigger silently ignored                 | `pnpm run review:switch -- --to gemini`                                             |
+| Codex (`chatgpt-codex-connector[bot]`) | yes (Codex Cloud auto-reviews on PR open)    | no                               | gate-based: trusted human posts `@codex review`; bot-posted trigger rejected by connector             | `pnpm run review:switch -- --to codex`                                              |
+| Claude (self-hosted CLI)               | **yes** — local runner picks up `opened`     | **yes** — picks up `synchronize` | **automatic**: `ai-review-local` job runs `claude -p` directly; no trigger comment needed or accepted | push a new commit, or `pnpm run review:switch -- --to claude` to rerun the last job |
 
 Consequences for orchestration design:
 
-- Auto-retrigger on `synchronize` is not achievable from within a stock
-  GitHub Actions workflow.
+- Claude review auto-triggers on both `opened` and `synchronize` events —
+  every push to a PR is reviewed automatically without any manual step.
 - Gemini Code Assist's on-open auto-review covers the initial PR review.
-  Every subsequent push needs a manual trigger or a backend switch.
-- The `pnpm run review:switch` helper is the canonical one-shot
-  recovery path: it flips `AI_REVIEW_AGENT`, posts the correct native
-  trigger comment on behalf of the current user (via `gh` CLI, so the
-  comment is human-authored and trusted), and reruns the most recent
-  failed `AI Review` job on the current head SHA.
+  Every subsequent push to a gemini-reviewed PR needs a manual trigger or
+  a backend switch.
+- The `pnpm run review:switch` helper is the canonical one-shot recovery
+  path: it flips `AI_REVIEW_AGENT`, posts the correct native trigger comment
+  for gemini or codex (skipped for claude since the runner auto-picks up
+  the push), and reruns the most recent failed `AI Review` job.
 
 ## Review Gate
 
@@ -67,10 +68,9 @@ Consequences for orchestration design:
   `Critical`, `High`, `Medium`, and `Low` severity markers.
 - Codex path waits for native GitHub PR review output from
   `chatgpt-codex-connector[bot]`.
-- Claude path waits for a top-level `claude[bot]` comment containing:
-  - `AI_REVIEW_AGENT: claude`
-  - `AI_REVIEW_SHA: <head sha>`
-  - `AI_REVIEW_OUTCOME: pass|advisory|block`
+- Claude path bypasses the gate entirely. The `ai-review-local` job runs
+  `claude -p` directly on the self-hosted runner, posts the review as a PR
+  comment, and the job succeeds or fails based on the CLI exit code.
 
 ## Feature Memory Gate
 

--- a/scripts/run-ai-pr-review.sh
+++ b/scripts/run-ai-pr-review.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Router: dispatches to the agent-specific review script based on AI_REVIEW_AGENT.
+set -euo pipefail
+
+agent="${AI_REVIEW_AGENT:-claude}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+case "$agent" in
+  claude) exec bash "$script_dir/run-claude-pr-review.sh" ;;
+  *) printf 'Unsupported local review agent: %s\n' "$agent" >&2; exit 1 ;;
+esac

--- a/scripts/run-claude-pr-review.sh
+++ b/scripts/run-claude-pr-review.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Runs a Claude CLI review for the given PR and posts the result as a comment.
+# Required env: PR_NUMBER, PR_BASE_REF, PR_HEAD_SHA, GITHUB_TOKEN
+# Optional env: CLAUDE_CLI_PATH (defaults to "claude")
+set -euo pipefail
+
+pr_number="${PR_NUMBER:?PR_NUMBER is required}"
+base_ref="${PR_BASE_REF:?PR_BASE_REF is required}"
+head_sha="${PR_HEAD_SHA:?PR_HEAD_SHA is required}"
+claude_bin="${CLAUDE_CLI_PATH:-claude}"
+
+# Fetch base branch so merge-base is available
+git fetch --no-tags origin "$base_ref"
+base_sha=$(git merge-base "origin/$base_ref" "$head_sha")
+
+# Build diff context — cap at 64 KB to stay within model context
+changed_files=$(git diff --name-only "$base_sha" "$head_sha")
+diff_output=$(git diff --unified=3 "$base_sha" "$head_sha" | head -c 65536)
+
+# Load versioned prompt template
+template=$(cat ".github/claude/prompts/pr-review.md")
+
+# Assemble full prompt
+prompt=$(printf '%s\n\n### Changed files\n\n%s\n\n### Diff\n\n```diff\n%s\n```' \
+  "$template" "$changed_files" "$diff_output")
+
+# Invoke Claude CLI in non-interactive print mode
+stderr_log=$(mktemp /tmp/claude-review-stderr.XXXXXX)
+review=$(printf '%s' "$prompt" | "$claude_bin" -p --output-format text \
+  --permission-mode default 2>"$stderr_log")
+exit_code=$?
+
+if [ "$exit_code" -ne 0 ]; then
+  printf 'Claude CLI exited %s:\n' "$exit_code" >&2
+  cat "$stderr_log" >&2
+  rm -f "$stderr_log"
+  exit "$exit_code"
+fi
+rm -f "$stderr_log"
+
+# Post review as a PR comment
+gh pr comment "$pr_number" --body "<!-- ai-review-local -->
+
+$review"

--- a/scripts/run-claude-pr-review.sh
+++ b/scripts/run-claude-pr-review.sh
@@ -27,7 +27,7 @@ prompt=$(printf '%s\n\n### Changed files\n\n%s\n\n### Diff\n\n```diff\n%s\n```' 
 # Invoke Claude CLI in non-interactive print mode
 stderr_log=$(mktemp /tmp/claude-review-stderr.XXXXXX)
 review=$(printf '%s' "$prompt" | "$claude_bin" -p --output-format text \
-  --permission-mode default 2>"$stderr_log")
+  --permission-mode bypassPermissions 2>"$stderr_log")
 exit_code=$?
 
 if [ "$exit_code" -ne 0 ]; then

--- a/scripts/run-claude-pr-review.sh
+++ b/scripts/run-claude-pr-review.sh
@@ -26,8 +26,8 @@ prompt=$(printf '%s\n\n### Changed files\n\n%s\n\n### Diff\n\n```diff\n%s\n```' 
 
 # Invoke Claude CLI in non-interactive print mode
 stderr_log=$(mktemp /tmp/claude-review-stderr.XXXXXX)
-review=$(printf '%s' "$prompt" | "$claude_bin" -p --output-format text \
-  --permission-mode bypassPermissions 2>"$stderr_log")
+review=$(printf '%s' "$prompt" | timeout 600 "$claude_bin" -p --output-format text \
+  2>"$stderr_log")
 exit_code=$?
 
 if [ "$exit_code" -ne 0 ]; then

--- a/scripts/run-claude-pr-review.sh
+++ b/scripts/run-claude-pr-review.sh
@@ -26,7 +26,7 @@ prompt=$(printf '%s\n\n### Changed files\n\n%s\n\n### Diff\n\n```diff\n%s\n```' 
 
 # Invoke Claude CLI in non-interactive print mode
 stderr_log=$(mktemp /tmp/claude-review-stderr.XXXXXX)
-review=$(printf '%s' "$prompt" | timeout 600 "$claude_bin" -p --output-format text \
+review=$(printf '%s' "$prompt" | "$claude_bin" -p --output-format text \
   2>"$stderr_log")
 exit_code=$?
 

--- a/scripts/switch-review-agent.mjs
+++ b/scripts/switch-review-agent.mjs
@@ -48,10 +48,12 @@ if (!validAgents.has(options.to)) {
   throw new Error(`--to must be one of: codex, gemini, claude\n\n${usage}`);
 }
 
+// claude uses a self-hosted local runner that auto-triggers from push events;
+// no trigger comment is needed or accepted.
 const triggerBodies = {
   codex: "@codex review",
   gemini: "/gemini review",
-  claude: "@claude review once",
+  claude: null,
 };
 
 const run = (command, commandArgs) =>
@@ -87,18 +89,16 @@ run("gh", [
 console.log(`Repository variable AI_REVIEW_AGENT set to ${options.to}.`);
 
 // Step 2: post the native trigger comment on the target PR.
-if (options.comment) {
-  run("gh", [
-    "pr",
-    "comment",
-    options.pr,
-    "--body",
-    triggerBodies[options.to],
-    ...repoArgs,
-  ]);
-  console.log(`Posted "${triggerBodies[options.to]}" on PR #${options.pr}.`);
+const triggerBody = triggerBodies[options.to];
+if (!options.comment || triggerBody === null) {
+  const reason =
+    triggerBody === null
+      ? `${options.to} uses a self-hosted local runner; no trigger comment needed`
+      : "--no-comment was used";
+  console.log(`Skipped native trigger comment: ${reason}.`);
 } else {
-  console.log("Skipped native trigger comment because --no-comment was used.");
+  run("gh", ["pr", "comment", options.pr, "--body", triggerBody, ...repoArgs]);
+  console.log(`Posted "${triggerBody}" on PR #${options.pr}.`);
 }
 
 // Step 3: rerun the most recent failed AI Review run at the current head SHA.

--- a/specs/005-local-claude-runner/plan.md
+++ b/specs/005-local-claude-runner/plan.md
@@ -1,0 +1,29 @@
+# 005 — Implementation Plan
+
+## Approach
+
+Four layers in dependency order:
+
+1. **Prompt** — create `.github/claude/prompts/pr-review.md` with
+   pallete-maker review priorities; this is pure content and has no deps.
+
+2. **Scripts** — `run-ai-pr-review.sh` (router) and
+   `run-claude-pr-review.sh` (executor); both call `resolve-pr-context.mjs`
+   outputs injected as env vars from the workflow.
+
+3. **Workflow** — split `ai-review.yml` into two jobs:
+   - `ai-review` (existing, gate-based) — condition restricted to
+     `gemini | codex | ''`
+   - `ai-review-local` (new, self-hosted) — runs only when
+     `AI_REVIEW_AGENT == 'claude'`
+
+4. **Tooling** — `switch-review-agent.mjs` skips trigger comment for claude
+   since push auto-triggers the local job.
+
+## Risks
+
+- Self-hosted runner must be registered and online; if offline the job queues
+  silently. Document the setup and fallback (`review:switch --to gemini`).
+- Diff cap (64 KB) may truncate very large PRs; acceptable trade-off.
+- `claude -p` session must be authenticated; document `claude auth` as a
+  prerequisite in the runner setup guide.

--- a/specs/005-local-claude-runner/spec.md
+++ b/specs/005-local-claude-runner/spec.md
@@ -1,0 +1,53 @@
+# 005 — Local Claude Runner for AI Review
+
+## Status
+
+Active
+
+## Goal
+
+Replace the gate-based Claude App review path with a self-hosted macOS runner
+that calls the Claude CLI directly. Reviews trigger automatically on every
+`pull_request` push without requiring a human-authored `@claude review once`
+comment or an `ANTHROPIC_API_KEY` secret.
+
+## Scope
+
+- Add `ai-review-local` job to `ai-review.yml` that runs on
+  `[self-hosted, macOS, ai-runner]` when `AI_REVIEW_AGENT=claude`
+- Restrict the existing gate-based `ai-review` job to gemini and codex only
+- Create `scripts/run-ai-pr-review.sh` (router) and
+  `scripts/run-claude-pr-review.sh` (executor)
+- Create `.github/claude/prompts/pr-review.md` (versioned review prompt)
+- Update `scripts/switch-review-agent.mjs` — no trigger comment for claude
+- Update `docs_pallete_maker/project/devops/ai-runner.md`
+
+## Non-goals
+
+- Setting up the self-hosted runner daemon itself (documented separately in
+  `docs_pallete_maker/project/devops/macos-local-runners.md`)
+- Changing gemini or codex review paths
+- Changing the implementation agent selection
+
+## Architecture
+
+```
+AI_REVIEW_AGENT=claude
+  └─► ai-review-local job (self-hosted, macOS, ai-runner)
+        └─► scripts/run-ai-pr-review.sh
+              └─► scripts/run-claude-pr-review.sh
+                    └─► claude -p < prompt → gh pr comment
+
+AI_REVIEW_AGENT=gemini | codex | (unset → gemini)
+  └─► ai-review job (ubuntu-latest) — unchanged
+        └─► scripts/ai-review-gate.mjs
+```
+
+## Acceptance Criteria
+
+- [ ] Push to a PR with `AI_REVIEW_AGENT=claude` triggers `ai-review-local` on
+      the self-hosted runner without any human comment
+- [ ] The review appears as a PR comment within the job timeout (15 min)
+- [ ] Push to a PR with `AI_REVIEW_AGENT=gemini` still uses the gate path unchanged
+- [ ] `pnpm run review:switch -- --to claude` no longer posts a trigger comment
+- [ ] `pnpm run ci` stays green

--- a/specs/005-local-claude-runner/tasks.md
+++ b/specs/005-local-claude-runner/tasks.md
@@ -1,0 +1,18 @@
+# 005 — Tasks
+
+## Implementation
+
+- [ ] Create `.github/claude/prompts/pr-review.md`
+- [ ] Create `scripts/run-ai-pr-review.sh` (router)
+- [ ] Create `scripts/run-claude-pr-review.sh` (executor)
+- [ ] Update `.github/workflows/ai-review.yml` — add `ai-review-local` job, restrict `ai-review` to gemini/codex
+- [ ] Update `scripts/switch-review-agent.mjs` — skip trigger comment for claude
+- [ ] Update `docs_pallete_maker/project/devops/ai-runner.md`
+
+## Tests
+
+- [ ] Keep `pnpm run ci` green
+
+## Docs
+
+- [ ] Open PR with verification notes


### PR DESCRIPTION
## Summary

- Adds `ai-review-local` job to `ai-review.yml` that runs on `[self-hosted, macOS, ai-runner]` when `AI_REVIEW_AGENT=claude`
- Restricts existing gate-based `ai-review` job to gemini and codex only
- Claude reviews now trigger automatically on every PR push — no `@claude review once` comment, no `ANTHROPIC_API_KEY` needed
- Prompt versioned in `.github/claude/prompts/pr-review.md` with pallete-maker review priorities
- `pnpm run review:switch -- --to claude` skips trigger comment (self-hosted runner auto-picks up the push)

## Architecture

```
AI_REVIEW_AGENT=claude  →  ai-review-local (self-hosted, macOS, ai-runner)
                               └─► run-ai-pr-review.sh → run-claude-pr-review.sh
                                     └─► claude -p < prompt → gh pr comment

AI_REVIEW_AGENT=gemini|codex  →  ai-review (ubuntu-latest, unchanged)
                                     └─► ai-review-gate.mjs
```

## Test plan

- [ ] `pnpm run ci` green (38/38 tests, build, format)
- [ ] With `AI_REVIEW_AGENT=claude` set: push triggers `ai-review-local` on self-hosted runner (requires runner to be registered and online)
- [ ] With `AI_REVIEW_AGENT=gemini`: existing gate path unchanged
- [ ] `pnpm run review:switch -- --to claude` logs "no trigger comment needed" and reruns last job

## Runner setup (prerequisite before merge)

Register self-hosted runner on Mac with labels `self-hosted`, `macOS`, `ai-runner`:

```bash
# Follow GitHub → Settings → Actions → Runners → New self-hosted runner (macOS)
# Set CLAUDE_CLI_PATH repo variable if claude is not on $PATH
gh variable set CLAUDE_CLI_PATH --body "/path/to/claude"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)