### PR TITLE
fix: switch-review-agent posts @claude review once after local runner rollback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ pallete-maker/
 │   ├── publish-branch.mjs              # Push branch and open or reuse PR
 │   ├── resolve-pr-context.mjs          # Pull request context resolver for workflows
 │   ├── ai-review-gate.mjs              # Review gate for Codex/Claude/Gemini
-│   └── switch-review-agent.mjs         # One-shot review backend switcher
+│   └── switch-review-agent.mjs         # One-shot review backend switcher (posts human trigger comment for all three agents)
 ├── docs_pallete_maker/
 │   ├── README.md                       # Durable docs index
 │   ├── adr/                            # Architecture decision records

--- a/scripts/switch-review-agent.mjs
+++ b/scripts/switch-review-agent.mjs
@@ -48,12 +48,13 @@ if (!validAgents.has(options.to)) {
   throw new Error(`--to must be one of: codex, gemini, claude\n\n${usage}`);
 }
 
-// claude uses a self-hosted local runner that auto-triggers from push events;
-// no trigger comment is needed or accepted.
+// All three review backends are triggered by a human-authored comment on
+// the PR. See docs_pallete_maker/project/devops/review-trigger-automation.md
+// for why bot-posted comments are rejected.
 const triggerBodies = {
   codex: "@codex review",
   gemini: "/gemini review",
-  claude: null,
+  claude: "@claude review once",
 };
 
 const run = (command, commandArgs) =>
@@ -90,12 +91,8 @@ console.log(`Repository variable AI_REVIEW_AGENT set to ${options.to}.`);
 
 // Step 2: post the native trigger comment on the target PR.
 const triggerBody = triggerBodies[options.to];
-if (!options.comment || triggerBody === null) {
-  const reason =
-    triggerBody === null
-      ? `${options.to} uses a self-hosted local runner; no trigger comment needed`
-      : "--no-comment was used";
-  console.log(`Skipped native trigger comment: ${reason}.`);
+if (!options.comment) {
+  console.log("Skipped native trigger comment: --no-comment was used.");
 } else {
   run("gh", ["pr", "comment", options.pr, "--body", triggerBody, ...repoArgs]);
   console.log(`Posted "${triggerBody}" on PR #${options.pr}.`);

--- a/specs/007-fix-switch-review-agent/plan.md
+++ b/specs/007-fix-switch-review-agent/plan.md
@@ -1,0 +1,20 @@
+# Plan — 007-fix-switch-review-agent
+
+## Approach
+
+Two minimal edits to `scripts/switch-review-agent.mjs`:
+
+1. Replace the `triggerBodies` map entry for `claude` with `"@claude review once"` and update the header comment.
+2. Simplify step 2 by removing the `triggerBody === null` branch; all three agents now have a trigger comment.
+
+Plus one-line note in `AGENTS.md` script tree so the guard docs-coverage check is satisfied.
+
+## Risks
+
+- None runtime-visible; the change only activates a previously dead code path for `--to claude`.
+- If someone relied on `--to claude` being a no-op for trigger comment (unlikely; the switch command's purpose is to also trigger the new reviewer), they can still pass `--no-comment`.
+
+## Done when
+
+- Spec acceptance criteria met.
+- PR #10 checks green and merged.

--- a/specs/007-fix-switch-review-agent/spec.md
+++ b/specs/007-fix-switch-review-agent/spec.md
@@ -1,0 +1,23 @@
+# Spec 007 — Fix switch-review-agent for Claude comment trigger
+
+## Problem
+
+After PR #9 removed the local self-hosted Claude runner, `scripts/switch-review-agent.mjs` still encoded `triggerBodies.claude = null` with the rationale "claude uses a self-hosted local runner that auto-triggers from push events". Running `pnpm run review:switch -- --to claude` would silently skip posting the trigger comment, leaving Claude Review un-invoked.
+
+## Goals
+
+- `pnpm run review:switch -- --to claude` posts `@claude review once` on the target PR.
+- All three review backends (`gemini`, `codex`, `claude`) are handled uniformly — each has a human-authored trigger comment.
+- Header comment in the script points to `docs_pallete_maker/project/devops/review-trigger-automation.md` for the constraint rationale.
+
+## Non-goals
+
+- Implementing Tier 1/2/3 automation from `review-trigger-automation.md`.
+- Touching `claude-review.yml` itself (it already gates on `author_association` and works for human-posted comments).
+
+## Acceptance criteria
+
+- `triggerBodies.claude === "@claude review once"` in `scripts/switch-review-agent.mjs`.
+- The `triggerBody === null` special case in step 2 is removed; only `--no-comment` skips posting.
+- `AGENTS.md` script table note mentions the new uniform behavior.
+- `pnpm run format:check`, `pnpm run check:repo`, build, tests all pass.

--- a/specs/007-fix-switch-review-agent/tasks.md
+++ b/specs/007-fix-switch-review-agent/tasks.md
@@ -1,0 +1,8 @@
+# Tasks — 007-fix-switch-review-agent
+
+- [x] T001: Update `triggerBodies.claude` from `null` to `"@claude review once"` and replace header comment in `scripts/switch-review-agent.mjs`
+- [x] T002: Remove the `triggerBody === null` branch in step 2 of `scripts/switch-review-agent.mjs`
+- [x] T003: Update `AGENTS.md` script tree note for `switch-review-agent.mjs`
+- [x] T004: `pnpm run format:check` passes
+- [x] T005: `pnpm run check:repo` passes
+- [x] T006: Open PR against main


### PR DESCRIPTION
## Summary

Follow-up to #9. After the local self-hosted Claude runner was removed, `scripts/switch-review-agent.mjs` still treated `claude` as a no-trigger-comment case (`triggerBodies.claude = null`). That was correct while the local runner auto-triggered on push, but now Claude review is handled by `claude-review.yml` which requires a human `@claude review once` comment — so `pnpm run review:switch -- --to claude` silently skipped the trigger and left the new reviewer un-invoked.

## Changes

- `triggerBodies.claude`: `null` → `"@claude review once"`.
- Dropped the `triggerBody === null` branch in step 2; all three backends now have trigger bodies.
- Updated header comment to reference `docs_pallete_maker/project/devops/review-trigger-automation.md` (the human-comment constraint rationale) instead of the now-removed self-hosted runner notes.

Found during critic triage of Gemini's review on #9. Gemini missed this; the critic flagged it as a deferred follow-up.

## Test plan

- [x] `node -c scripts/switch-review-agent.mjs` (syntax)
- [x] `pnpm run format:check`
- [x] `pnpm run check:repo`
- [ ] Manual: `pnpm run review:switch -- --to claude --pr <N>` on a test PR posts `@claude review once` and triggers `claude-review.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)