### PR TITLE
chore: security hardening — CSP, OSV scan, Dependabot, SHA-pinned actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Europe/Moscow"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Europe/Moscow"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "npm"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3

--- a/.github/workflows/claude-agent.yml
+++ b/.github/workflows/claude-agent.yml
@@ -108,7 +108,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run Claude implementation agent
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@c3d45e8e941e1b2ad7b278c57482d9c5bf1f35b3 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -103,7 +103,7 @@ jobs:
           ref: ${{ steps.pr.outputs.checkout_ref }}
 
       - name: Run Claude review agent
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@c3d45e8e941e1b2ad7b278c57482d9c5bf1f35b3 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |

--- a/.github/workflows/osv-scan.yml
+++ b/.github/workflows/osv-scan.yml
@@ -1,0 +1,31 @@
+name: OSV Scan
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  osv-scan:
+    name: osv-scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run OSV Scanner
+        uses: google/osv-scanner-action/osv-scanner-action@c51854704019a247608d928f370c98740469d4b5 # v2.3.5
+        with:
+          scan-args: |-
+            --lockfile=pnpm-lock.yaml
+            --format=table

--- a/docs_pallete_maker/project/devops/vercel-cd.md
+++ b/docs_pallete_maker/project/devops/vercel-cd.md
@@ -39,3 +39,40 @@ Do not treat manual dashboard edits as the delivery path. Product behavior shoul
 
 Preview validation and post-merge smoke are documented in
 `docs_pallete_maker/project/devops/delivery-playbook.md`.
+
+## Security Headers
+
+`vercel.json` sets response headers for every path as a baseline hardening
+layer for the static site:
+
+- **Content-Security-Policy** — `default-src 'self'`; explicit allowlist for
+  `cdnjs.cloudflare.com` (html2canvas) and Google Fonts
+  (`fonts.googleapis.com` CSS + `fonts.gstatic.com` WOFF). Any additional
+  external origin added to `index.html` must be added here in the same PR,
+  otherwise the browser will block it.
+- **Strict-Transport-Security** — HSTS with `max-age=63072000; includeSubDomains; preload`.
+- **X-Frame-Options: DENY** and `frame-ancestors 'none'` in CSP — blocks
+  embedding in third-party iframes (anti-clickjacking).
+- **X-Content-Type-Options: nosniff**, **Referrer-Policy**, **Permissions-Policy** —
+  standard defense-in-depth defaults.
+
+Inline scripts and styles currently require `'unsafe-inline'` in the CSP
+because the build inlines `src/scripts/harmony.mjs` into `dist/index.html`
+and the styles live in `<style>` tags. Tightening this to nonces or hashes
+is a future improvement.
+
+## Supply-chain Hygiene
+
+- **OSV Scanner** (`.github/workflows/osv-scan.yml`) runs on every PR, push
+  to `main`, and weekly on schedule. It checks `pnpm-lock.yaml` against
+  Google's Open Source Vulnerabilities database and fails the check on any
+  known CVE. Broader coverage than `npm audit`.
+- **Dependabot** (`.github/dependabot.yml`) opens weekly update PRs for
+  `github-actions` and `npm` ecosystems with a 7-day cooldown on new
+  releases (14 days for major bumps, 3 for patches). The cooldown protects
+  against freshly compromised releases.
+- **Pinned action SHAs** — third-party GitHub Actions are pinned to a
+  commit SHA with a trailing `# v<tag>` comment (see
+  `anthropics/claude-code-action`, `google/osv-scanner-action`). Moving
+  tags like `@v1` can be force-pushed to a different commit; a SHA cannot.
+  Official `actions/*` are pinned to major tags for readability.

--- a/specs/008-security-hardening/plan.md
+++ b/specs/008-security-hardening/plan.md
@@ -1,0 +1,24 @@
+# Plan — 008-security-hardening
+
+## Approach
+
+Single PR, five surface areas, all declarative config. No runtime code touched.
+
+1. **Response headers** — add `headers` array in `vercel.json`. CSP allowlist mirrors the exact external origins in `index.html` (`cdnjs.cloudflare.com`, `fonts.googleapis.com`, `fonts.gstatic.com`). `'unsafe-inline'` retained for scripts and styles because the static build inlines `harmony.mjs` and CSS variables.
+2. **OSV scan** — new workflow `osv-scan.yml`, uses `google/osv-scanner-action/osv-scanner-action@<sha>` pointing to v2.3.5, scans `pnpm-lock.yaml`, table format for PR log readability.
+3. **Dependabot** — new `.github/dependabot.yml`, two ecosystems (`github-actions`, `npm`), Monday 07:00 Europe/Moscow, cooldown per semver level.
+4. **SHA-pinning** — resolve `anthropics/claude-code-action@v1` via `gh api repos/anthropics/claude-code-action/git/refs/tags/v1` → annotated tag → commit SHA `c3d45e8e…`. Apply in `claude-agent.yml:111` and `claude-review.yml:106`. Keep `# v1` trailing comment.
+5. **Docs** — append *Security Headers* and *Supply-chain Hygiene* sections to `vercel-cd.md`.
+
+## Risks
+
+- **CSP breaks the page** if an origin is missed. Mitigation: preview deploy per PR; verify browser console before merge.
+- **OSV Scan flags transitive deps we can't fix quickly.** Mitigation: the scan runs on `pnpm-lock.yaml` and the repo has only three dev-deps (`html-validate`, `prettier`, `tailwindcss`); false-positive surface is small. If it fails, triage via `critic` subagent.
+- **Dependabot PR noise.** Mitigation: `open-pull-requests-limit: 5` per ecosystem, cooldown settings.
+- **`unsafe-inline` leaves XSS surface.** Accepted for now; tracked as non-goal.
+
+## Done when
+
+- All Spec 008 acceptance criteria met.
+- PR #11 all checks green (CI, PR Guard, OSV Scan, AI Review, Vercel preview).
+- Browser smoke on preview URL shows no console CSP violations on golden path.

--- a/specs/008-security-hardening/plan.md
+++ b/specs/008-security-hardening/plan.md
@@ -8,7 +8,7 @@ Single PR, five surface areas, all declarative config. No runtime code touched.
 2. **OSV scan** — new workflow `osv-scan.yml`, uses `google/osv-scanner-action/osv-scanner-action@<sha>` pointing to v2.3.5, scans `pnpm-lock.yaml`, table format for PR log readability.
 3. **Dependabot** — new `.github/dependabot.yml`, two ecosystems (`github-actions`, `npm`), Monday 07:00 Europe/Moscow, cooldown per semver level.
 4. **SHA-pinning** — resolve `anthropics/claude-code-action@v1` via `gh api repos/anthropics/claude-code-action/git/refs/tags/v1` → annotated tag → commit SHA `c3d45e8e…`. Apply in `claude-agent.yml:111` and `claude-review.yml:106`. Keep `# v1` trailing comment.
-5. **Docs** — append *Security Headers* and *Supply-chain Hygiene* sections to `vercel-cd.md`.
+5. **Docs** — append _Security Headers_ and _Supply-chain Hygiene_ sections to `vercel-cd.md`.
 
 ## Risks
 

--- a/specs/008-security-hardening/spec.md
+++ b/specs/008-security-hardening/spec.md
@@ -1,0 +1,36 @@
+# Spec 008 — Security Hardening: CSP, OSV, Dependabot, SHA-pinned Actions
+
+## Problem
+
+After the local Claude runner rollback (PRs #9/#10) the repository had several residual supply-chain gaps:
+
+- `vercel.json` set no response headers — external scripts could be swapped at CDN level and the browser would execute anything served. No HSTS, no clickjacking protection.
+- No vulnerability scan on dependencies. `npm audit` is not part of CI and would miss many OSV-covered CVEs.
+- Third-party GitHub Actions were pinned to moving tags (`anthropics/claude-code-action@v1`). Moving tags can be re-pointed; a SHA cannot.
+- No automation for keeping actions and npm deps current.
+
+The vibecode.morecil.ru/ru wiki review (2026-04-17) surfaced OSV Scanner, SHA-pinning, and explicit CSP/HSTS gates as concrete low-cost mitigations.
+
+## Goals
+
+- Baseline security headers (CSP, HSTS, X-Frame-Options, nosniff, Referrer-Policy, Permissions-Policy) on every response from Vercel.
+- Automated vulnerability scan on every PR, push to `main`, and weekly schedule.
+- Third-party actions pinned to commit SHA with trailing `# v<tag>` comment for readability.
+- Automated update PRs for actions and npm with cooldown protection against freshly compromised releases.
+- Durable documentation of the policy in `docs_pallete_maker/project/devops/vercel-cd.md`.
+
+## Non-goals
+
+- Tightening CSP to nonces/hashes — requires reworking `build-static.mjs` inlining, tracked as follow-up.
+- Removing dead local-runner code left in `main` after PR #9 — separate cleanup PR.
+- Changing Vercel project settings; all hardening is in-repo.
+
+## Acceptance criteria
+
+- `vercel.json` declares `Content-Security-Policy`, `Strict-Transport-Security`, `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy` for `/(.*)`.
+- `.github/workflows/osv-scan.yml` present, triggers on `pull_request`, `push` to `main`, weekly cron, and `workflow_dispatch`; uses pinned SHA for `google/osv-scanner-action`.
+- `.github/dependabot.yml` configures `github-actions` and `npm` with weekly interval and cooldown (default 7, major 14, minor 7, patch 3 days).
+- `anthropics/claude-code-action` pinned to SHA in `claude-agent.yml` and `claude-review.yml`.
+- `docs_pallete_maker/project/devops/vercel-cd.md` documents headers and supply-chain hygiene.
+- All existing checks pass: `pnpm run ci`, PR Guard (docs coverage + feature memory), OSV Scan, AI Review.
+- Preview deployment in the browser shows no CSP violations on golden path (open palette tool, select colors, export PNG).

--- a/specs/008-security-hardening/tasks.md
+++ b/specs/008-security-hardening/tasks.md
@@ -1,0 +1,12 @@
+# Tasks — 008-security-hardening
+
+- [x] T001: Add `headers` block to `vercel.json` with CSP, HSTS, X-Frame-Options, nosniff, Referrer-Policy, Permissions-Policy
+- [x] T002: Resolve `anthropics/claude-code-action@v1` to commit SHA via `gh api` and pin in `claude-agent.yml` and `claude-review.yml` with `# v1` trailing comment
+- [x] T003: Create `.github/workflows/osv-scan.yml`, pin `google/osv-scanner-action` to v2.3.5 SHA, trigger on PR/push/weekly/dispatch
+- [x] T004: Create `.github/dependabot.yml` for `github-actions` and `npm` with weekly schedule and per-semver cooldown
+- [x] T005: Append *Security Headers* and *Supply-chain Hygiene* sections to `docs_pallete_maker/project/devops/vercel-cd.md`
+- [x] T006: `pnpm run ci` passes locally (38/38 tests, HTML valid, build, format, baseline)
+- [x] T007: Open PR #11 against `main`
+- [ ] T008: All PR #11 checks green (CI, PR Guard, OSV Scan, AI Review, Vercel)
+- [ ] T009: Browser smoke on preview URL — no CSP console violations on golden path (select colors, export PNG)
+- [ ] T010: Merge PR #11 after all checks COMPLETED + SUCCESSFUL per `feedback_never_merge_before_review.md`

--- a/specs/008-security-hardening/tasks.md
+++ b/specs/008-security-hardening/tasks.md
@@ -7,7 +7,7 @@
 - [x] T005: Append _Security Headers_ and _Supply-chain Hygiene_ sections to `docs_pallete_maker/project/devops/vercel-cd.md`
 - [x] T006: `pnpm run ci` passes locally (38/38 tests, HTML valid, build, format, baseline)
 - [x] T007: Open PR #11 against `main`
-- [x] T008a: baseline-checks / guard / osv-scan / Vercel green on `8a1f50c`
-- [ ] T008b: AI Review green — **BLOCKED on confirmed Gemini hallucinations** (2× HIGH on `cooldown` "not supported" contradicted by official Dependabot docs; 2× MEDIUM claiming files missing that are present in diff). See PR comment for triage evidence. Requires user decision: (A) switch `AI_REVIEW_AGENT` to `codex` or `claude` for this PR and re-run; (B) accept failure and merge with override.
-- [ ] T009: Browser smoke on preview URL — **SKIPPED in automated run**: preview deploy is behind Vercel SSO (curl returns 401). Must be done manually by the user before merge; instructions posted in PR comment.
-- [ ] T010: Merge PR #11 after all checks COMPLETED + SUCCESSFUL per `feedback_never_merge_before_review.md` — requires user decision on T008b first.
+- [x] T008a: baseline-checks / guard / osv-scan / Vercel green on `1e71d51`
+- [x] T008b: AI Review — resolved by switching `AI_REVIEW_AGENT` `gemini` → `codex` (2026-04-17). Codex reviewed and posted "Didn't find any major issues. Nice work!" twice. `ai-review-gate` dispatch run (`24574085471`) passed with SUCCESS.
+- [x] T009: Browser smoke on preview URL — user verified manually (2026-04-17). Only non-app CSP violation is Vercel's own `vercel.live/_next-live/feedback/feedback.js` preview widget, correctly blocked by our CSP; app golden path (palette select + PNG export) produces zero CSP violations.
+- [ ] T010: Merge PR #11 after all checks COMPLETED + SUCCESSFUL per `feedback_never_merge_before_review.md` — user decision.

--- a/specs/008-security-hardening/tasks.md
+++ b/specs/008-security-hardening/tasks.md
@@ -7,6 +7,7 @@
 - [x] T005: Append _Security Headers_ and _Supply-chain Hygiene_ sections to `docs_pallete_maker/project/devops/vercel-cd.md`
 - [x] T006: `pnpm run ci` passes locally (38/38 tests, HTML valid, build, format, baseline)
 - [x] T007: Open PR #11 against `main`
-- [ ] T008: All PR #11 checks green (CI, PR Guard, OSV Scan, AI Review, Vercel)
-- [ ] T009: Browser smoke on preview URL — no CSP console violations on golden path (select colors, export PNG)
-- [ ] T010: Merge PR #11 after all checks COMPLETED + SUCCESSFUL per `feedback_never_merge_before_review.md`
+- [x] T008a: baseline-checks / guard / osv-scan / Vercel green on `8a1f50c`
+- [ ] T008b: AI Review green — **BLOCKED on confirmed Gemini hallucinations** (2× HIGH on `cooldown` "not supported" contradicted by official Dependabot docs; 2× MEDIUM claiming files missing that are present in diff). See PR comment for triage evidence. Requires user decision: (A) switch `AI_REVIEW_AGENT` to `codex` or `claude` for this PR and re-run; (B) accept failure and merge with override.
+- [ ] T009: Browser smoke on preview URL — **SKIPPED in automated run**: preview deploy is behind Vercel SSO (curl returns 401). Must be done manually by the user before merge; instructions posted in PR comment.
+- [ ] T010: Merge PR #11 after all checks COMPLETED + SUCCESSFUL per `feedback_never_merge_before_review.md` — requires user decision on T008b first.

--- a/specs/008-security-hardening/tasks.md
+++ b/specs/008-security-hardening/tasks.md
@@ -4,7 +4,7 @@
 - [x] T002: Resolve `anthropics/claude-code-action@v1` to commit SHA via `gh api` and pin in `claude-agent.yml` and `claude-review.yml` with `# v1` trailing comment
 - [x] T003: Create `.github/workflows/osv-scan.yml`, pin `google/osv-scanner-action` to v2.3.5 SHA, trigger on PR/push/weekly/dispatch
 - [x] T004: Create `.github/dependabot.yml` for `github-actions` and `npm` with weekly schedule and per-semver cooldown
-- [x] T005: Append *Security Headers* and *Supply-chain Hygiene* sections to `docs_pallete_maker/project/devops/vercel-cd.md`
+- [x] T005: Append _Security Headers_ and _Supply-chain Hygiene_ sections to `docs_pallete_maker/project/devops/vercel-cd.md`
 - [x] T006: `pnpm run ci` passes locally (38/38 tests, HTML valid, build, format, baseline)
 - [x] T007: Open PR #11 against `main`
 - [ ] T008: All PR #11 checks green (CI, PR Guard, OSV Scan, AI Review, Vercel)

--- a/vercel.json
+++ b/vercel.json
@@ -3,5 +3,36 @@
   "buildCommand": "pnpm run build",
   "outputDirectory": "dist",
   "cleanUrls": true,
-  "trailingSlash": false
+  "trailingSlash": false,
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+        },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=63072000; includeSubDomains; preload"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=(), interest-cohort=()"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Closes supply-chain gaps identified after the local Claude runner rollback, based on vibe-coding wiki findings (OSV Scanner, CSP/HSTS gate, SHA-pinning).

- **`vercel.json`** — adds `Content-Security-Policy`, `Strict-Transport-Security`, `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy`, `Permissions-Policy` as per-response headers. CSP explicitly allowlists `cdnjs.cloudflare.com` (html2canvas) and Google Fonts; any new external origin added to `index.html` must be added here in the same PR.
- **`.github/workflows/osv-scan.yml`** — runs Google OSV Scanner against `pnpm-lock.yaml` on every PR, push to `main`, and weekly. Fails the check on any known CVE. Broader coverage than `npm audit`.
- **`.github/dependabot.yml`** — weekly update PRs for `github-actions` and `npm` with a 7-day cooldown (14 days for major bumps, 3 for patches) to avoid freshly compromised releases.
- **SHA-pinned third-party actions** — `anthropics/claude-code-action@v1` → `@c3d45e8e…` in both `claude-agent.yml` and `claude-review.yml`. `google/osv-scanner-action` also pinned. Moving tags like `@v1` can be force-pushed; a SHA cannot. Official `actions/*` kept on major tags for readability.
- **`docs_pallete_maker/project/devops/vercel-cd.md`** — new *Security Headers* and *Supply-chain Hygiene* sections documenting the policy.

### Not addressed (follow-up)
- CSP still requires `'unsafe-inline'` for scripts/styles because `build-static.mjs` inlines `harmony.mjs` into `dist/index.html`. Tightening to nonces/hashes is a future PR.

## Test plan

- [x] `pnpm run ci` passes locally (38/38 tests, HTML valid, build, format, baseline)
- [ ] CI green on PR
- [ ] OSV Scan check appears and passes
- [ ] PR Guard passes (docs coverage satisfied via vercel-cd.md update)
- [ ] AI Review (Gemini) passes
- [ ] Preview deploy loads in browser; `curl -I` on preview URL shows new security headers
- [ ] Browser devtools console shows no CSP violations on the preview URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)