### PR TITLE
feat: 11-column picker grid aligned to header edges

### DIFF
--- a/docs_pallete_maker/project/frontend/frontend-docs.md
+++ b/docs_pallete_maker/project/frontend/frontend-docs.md
@@ -8,8 +8,9 @@ The application is a static SPA with a modular source layout:
 - `src/scripts/harmony.mjs` — pure ES module: palette data (`PM_PALETTE`, 51 colors) and all harmony functions (`getBase`, `isDimmed`, `isCompatible`, `getGrouped`, etc.). No DOM, no global state. Functions accept `palette` as an explicit parameter for testability.
 - `src/styles/tailwind.css` — pre-compiled Tailwind CSS v3 (minified); regenerate with `pnpm run build:css` after adding new utility classes
 - `src/styles/input.css` + `tailwind.config.cjs` — Tailwind build sources
-- `tests/harmony.test.mjs` — 35 unit tests via `node:test` (zero extra dependencies)
+- `tests/harmony.test.mjs` + `tests/ai-review-gate-regressions.test.mjs` — 59 unit tests via `node:test` (zero extra dependencies)
 - CDN dependencies: html2canvas 1.4.1 (PNG export, with SRI hash), Inter font via `@import`
+- Picker grid responsive columns: 3 / 4 / 6 / 8 / 11 at `480 / 640 / 1024 / 1280`px breakpoints; at `≥1280px` the grid shares `max-width: 80rem` with the header content so the edges align with the PALETTE logo and DOWNLOAD PNG button.
 
 ## Build Pipeline
 

--- a/index.html
+++ b/index.html
@@ -218,7 +218,8 @@
       }
       @media (min-width: 1280px) {
         #sourceGrid {
-          grid-template-columns: repeat(10, 1fr);
+          grid-template-columns: repeat(11, 1fr);
+          max-width: 80rem;
         }
       }
 

--- a/specs/012-grid-11-cols/plan.md
+++ b/specs/012-grid-11-cols/plan.md
@@ -1,0 +1,30 @@
+# Plan — 012-grid-11-cols
+
+## Approach
+
+Two-line change in the `@media (min-width: 1280px)` block of `index.html`:
+
+```css
+@media (min-width: 1280px) {
+  #sourceGrid {
+    grid-template-columns: repeat(11, 1fr);
+    max-width: 80rem;
+  }
+}
+```
+
+By matching `max-width: 80rem` to the header inner container's `max-w-7xl`, the grid sits in the same horizontal range as the header content. Both use the same `padding: 20px` on their parent (`header { padding: 20px }` and `main { padding: 20px }`), so the alignment is automatic.
+
+Math: 1280px container - 10 gaps × 12px = 1160px / 11 = ~105px column width. 88px swatch centered with ~8.5px each side. Visually similar density to the original 10-col-in-1200 layout, just with one more column.
+
+## Risks
+
+- Mobile breakpoints unchanged, so the change only affects ≥1280px viewports. No mobile regression.
+- Swatch CSS variables untouched, so no spillover into the drawer or export rendering.
+- `max-w-7xl` Tailwind class is stable (= 80rem since v2). Future Tailwind upgrade unlikely to change this.
+
+## Done when
+
+- Spec 012 acceptance criteria met.
+- All PR #15 checks green.
+- Visual eye-check on Vercel preview confirms alignment.

--- a/specs/012-grid-11-cols/spec.md
+++ b/specs/012-grid-11-cols/spec.md
@@ -1,0 +1,32 @@
+# Spec 012 — 11-column picker grid aligned to header edges
+
+## Problem
+
+Wide-breakpoint (≥1280px) picker grid currently shows 10 swatches per row inside `max-width: 1200px`. The grid is centered in the viewport with large empty side margins on wide displays, and its outer edges do not align with the header content (PALETTE logo on the left, DOWNLOAD PNG button on the right).
+
+User wants:
+
+- one extra swatch column at the wide breakpoint (10 → 11)
+- original swatch sizes preserved (`--swatch-outer: 88px`, `--swatch-inner: 72px`)
+- original header sizes preserved
+- grid outer edges visually aligned with the header content edges, by reducing the side margin only
+
+## Goals
+
+- 11 columns at the `min-width: 1280px` breakpoint, instead of 10.
+- Grid outer edges align with the PALETTE logo (left) and DOWNLOAD PNG button (right), since both sit in the header's `max-w-7xl` (= `80rem` / `1280px`) inner container.
+- All other breakpoints (3 / 4 / 6 / 8 columns) and CSS variables unchanged.
+
+## Non-goals
+
+- Changing swatch sizes, header markup, button position, or any unrelated CSS.
+- Touching the drawer or export rendering.
+- Editing other product files (this PR is one CSS rule change).
+
+## Acceptance criteria
+
+- `index.html` `@media (min-width: 1280px) { #sourceGrid { … } }` block has `grid-template-columns: repeat(11, 1fr)` and `max-width: 80rem`.
+- 51-color palette renders as 11 columns × 4 rows + 7 swatches in the 5th row at viewports ≥1280px.
+- Grid container width matches header `max-w-7xl` content width (1280px), so outer edges line up with logo left and DOWNLOAD PNG right.
+- Swatches stay at 88px outer / 72px inner.
+- All PR checks green: baseline-checks, guard, osv-scan, AI Review, Vercel.

--- a/specs/012-grid-11-cols/tasks.md
+++ b/specs/012-grid-11-cols/tasks.md
@@ -1,0 +1,8 @@
+# Tasks — 012-grid-11-cols
+
+- [x] T001: Change `repeat(10, 1fr)` → `repeat(11, 1fr)` in the `@media (min-width: 1280px)` block of `index.html`
+- [x] T002: Add `max-width: 80rem` to the same rule so grid edges align with header `max-w-7xl` content edges
+- [x] T003: `pnpm run preflight` passes (59/59 tests, build, format, baseline)
+- [ ] T004: All PR #15 checks green (baseline-checks, guard, osv-scan, AI Review, Vercel)
+- [ ] T005: User visually confirms alignment on Vercel preview deploy
+- [ ] T006: Merge PR #15 after all checks COMPLETED + SUCCESSFUL per `feedback_never_merge_before_review.md`


### PR DESCRIPTION
## Summary

Wide-breakpoint picker grid (≥1280px) now shows 11 columns instead of 10. Grid outer edges align with header content edges (PALETTE logo on the left, DOWNLOAD PNG button on the right) by sharing the same `max-width: 80rem` (1280px) as the header's `max-w-7xl` inner container.

- `--swatch-outer` and `--swatch-inner` unchanged (88px / 72px).
- Header layout untouched.
- Smaller breakpoints (3 / 4 / 6 / 8 cols at <1280px) unchanged.

## Test plan

- [x] `pnpm run preflight` passes (59/59 tests, build, format)
- [ ] CI green
- [ ] AI Review (Codex) pass
- [ ] Visual eye-check on preview deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)