### PR TITLE
chore: pin pnpm/action-setup + local pre-push hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -108,7 +108,7 @@ jobs:
         run: node scripts/check-feature-memory.mjs "$BASE_REF" "$HEAD_REF"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@
 - Никогда не мержить PR до завершения ВСЕХ проверок (включая `AI Review`), даже если GitHub показывает `MERGEABLE`/`UNSTABLE`. Ждать, пока все проверки станут `COMPLETED` и `SUCCESSFUL`.
 - Перед каждым `git push` прогоняй `pnpm run preflight` — он локально повторяет то, что делают PR Guard и CI (feature-memory gate + baseline + html + build + format + tests). Экономит итерации на публичных чеках.
 - Стиль commit-message: только subject (≤72 chars, conventional prefix `fix:`/`chore:`/`docs:`/etc.); body не пишу, кроме случая с неочевидным «why»; длинный контекст идёт в PR description, не в commit body.
+- Локальный pre-push hook: `.claude/hooks/check-feature-memory-on-push.sh` (зарегистрирован в `.claude/settings.local.json` как PreToolUse на Bash) блокирует `git push`, если committed product-path changes требуют `specs/<id>/{spec,plan,tasks}.md` и спека нет. `.claude/` gitignored — на новой машине восстановить вручную из spec 013. Emergency bypass: закомментировать hook в `.claude/settings.local.json` или запушить из обычного терминала.
 - Не ломай `pnpm run build`: проект должен оставаться deployable как статический сайт
 - При review фокусируйся на mobile grid reflow, harmony rules correctness, PNG export safety, RU-строках и maintainability
 

--- a/docs_pallete_maker/project/devops/vercel-cd.md
+++ b/docs_pallete_maker/project/devops/vercel-cd.md
@@ -71,8 +71,9 @@ is a future improvement.
   `github-actions` and `npm` ecosystems with a 7-day cooldown on new
   releases (14 days for major bumps, 3 for patches). The cooldown protects
   against freshly compromised releases.
-- **Pinned action SHAs** — third-party GitHub Actions are pinned to a
-  commit SHA with a trailing `# v<tag>` comment (see
-  `anthropics/claude-code-action`, `google/osv-scanner-action`). Moving
-  tags like `@v1` can be force-pushed to a different commit; a SHA cannot.
-  Official `actions/*` are pinned to major tags for readability.
+- **Pinned action SHAs.** Third-party GitHub Actions are pinned to a
+  commit SHA with a trailing `# v<tag>` comment. Currently pinned:
+  `anthropics/claude-code-action`, `google/osv-scanner-action`,
+  `pnpm/action-setup`. Moving tags like `@v1` can be force-pushed to a
+  different commit; a SHA cannot. Official `actions/*` are pinned to
+  major tags for readability.

--- a/specs/013-pin-pnpm-action-and-pre-push-hook/plan.md
+++ b/specs/013-pin-pnpm-action-and-pre-push-hook/plan.md
@@ -1,0 +1,42 @@
+# Plan — 013-pin-pnpm-action-and-pre-push-hook
+
+## Approach
+
+Two unrelated infra fixes batched because each is too small to justify its own PR.
+
+### A. Pin pnpm/action-setup
+
+1. Resolve `pnpm/action-setup@v4` → annotated tag → commit SHA via `gh api repos/pnpm/action-setup/git/refs/tags/v4` then `gh api repos/.../git/tags/<annotated-tag-sha>`. Result: `b906affcce14559ad1aafd4ab0e942779e9f58b1`.
+2. Apply `pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4` in both workflow files (ci.yml line 35, pr-guard.yml line 111).
+3. Document in `docs_pallete_maker/project/devops/vercel-cd.md` that pnpm/action-setup is now SHA-pinned (closes the only third-party-action exception).
+
+### C. Local Claude Code pre-push hook
+
+1. Write `.claude/hooks/check-feature-memory-on-push.sh`:
+   - Reads tool-input JSON from stdin (Claude Code hook contract)
+   - Extracts the `command` field via python3 (no jq dependency)
+   - Greps for `git push` (covers `--force`, `--with-lease`, chained commands)
+   - Runs `node scripts/check-feature-memory.mjs origin/main HEAD` from `$CLAUDE_PROJECT_DIR`
+   - Exits 2 with stderr message on failure (Claude Code convention for blocking + visible)
+   - Exits 0 otherwise
+2. Add `hooks.PreToolUse` entry to `.claude/settings.local.json` with matcher `Bash` and command pointing at the script via `$CLAUDE_PROJECT_DIR`.
+3. `chmod +x` the script.
+4. Smoke-test by piping fake JSON: `echo '{"tool_input":{"command":"git push"}}' | .claude/hooks/...sh` should exit 0 when committed state has no missing spec, exit 2 when it does.
+5. Document in CLAUDE.md «Важные правила»: hook exists, lives in `.claude/`, restore-on-clone instructions, emergency bypass (edit `.claude/settings.local.json` to comment out the hook, or run `git push` from a normal terminal where Claude Code is not active).
+
+`.claude/` is fully gitignored so the hook script and settings stay machine-local. CLAUDE.md is committed and serves as the only durable reference for re-establishing the hook on a new machine.
+
+## Risks
+
+- **Hook fires on every Bash call.** It exits 0 immediately for non-push commands, but adds a few ms of overhead per call. Acceptable.
+- **`python3` unavailable.** macOS bundles python3 since 12.3. Fallback path could use awk but adds complexity. Punt unless someone reports.
+- **`$CLAUDE_PROJECT_DIR` unset.** Script falls back to `pwd` which works in normal flows but may be wrong if Claude is run from a parent directory. Acceptable since Claude Code sets the var in modern versions.
+- **False positives.** If the hook misclassifies a non-push as a push (e.g. a comment-only string `"git push"` inside a different shell command), it would block. The regex requires whitespace before `git`, mitigating most cases.
+- **No test coverage for the hook itself.** It's a 25-line bash script with a clear purpose; behavioural test would require a fake project tree. Smoke-tested manually.
+
+## Done when
+
+- All Spec 013 acceptance criteria met.
+- `pnpm run preflight` passes.
+- All PR checks green.
+- The hook actively gates this very PR's push (or any future push) when a spec is missing.

--- a/specs/013-pin-pnpm-action-and-pre-push-hook/spec.md
+++ b/specs/013-pin-pnpm-action-and-pre-push-hook/spec.md
@@ -1,0 +1,31 @@
+# Spec 013 — Pin pnpm/action-setup to SHA + Local Pre-Push Feature-Memory Hook
+
+## Problem
+
+1. **README accuracy / supply-chain hygiene gap.** The merged PR #14 README (and current `docs_pallete_maker/project/devops/vercel-cd.md`) claim third-party GitHub Actions are pinned to commit SHA. Codex P3 finding on PR #14 correctly pointed out that `pnpm/action-setup@v4` in `.github/workflows/ci.yml` and `pr-guard.yml` is still a floating tag, not a SHA. The claim is therefore inaccurate AND the action is the only third-party action in the repo without SHA pinning.
+
+2. **Recurring spec-folder forgetting.** Across PRs #11, #12, #13, #14, and #15, Claude (the implementation agent) forgot to add the `specs/<NNN-slug>/` folder before pushing five times in a row, despite the existing memory rule and the `pnpm run preflight` script. The root cause is documented in `feedback_guard_feature_memory.md`: `preflight` only checks committed state, so running it before commit (the natural reflex) misses the issue.
+
+## Goals
+
+- `pnpm/action-setup` is pinned to a commit SHA in both `.github/workflows/ci.yml` and `.github/workflows/pr-guard.yml`, with a trailing `# v4` comment for readability.
+- README's SHA-pinning claim is accurate after this PR (no exceptions remaining among third-party actions).
+- A local Claude Code `PreToolUse` hook on `Bash` matching `git push` runs `node scripts/check-feature-memory.mjs origin/main HEAD` and blocks the push (exit 2) when product-path commits lack a `specs/<id>/` folder. Hook lives in `.claude/` (gitignored, machine-local).
+- CLAUDE.md documents the hook (where it lives, how to restore on another device, how to bypass for true emergencies).
+
+## Non-goals
+
+- Pinning `actions/*` (first-party GitHub-published actions); they remain on major tags per existing project policy.
+- Touching the docs-coverage step asymmetry in the guard (specs/ accepted by feature-memory but not by docs-coverage). Tracked separately.
+- Fixing PR #14's stale README sentence about SHA-pinning by editing the README; this PR makes the claim true by pinning the missing action.
+
+## Acceptance criteria
+
+- `.github/workflows/ci.yml` line for pnpm uses `pnpm/action-setup@<commit-sha> # v4` (SHA: `b906affcce14559ad1aafd4ab0e942779e9f58b1`).
+- `.github/workflows/pr-guard.yml` line for pnpm uses the same `@<sha> # v4` form.
+- `.claude/hooks/check-feature-memory-on-push.sh` exists, is executable, parses Claude Code's stdin JSON, matches `git push` commands, runs the feature-memory check, exits 2 with a helpful message on failure, exits 0 otherwise.
+- `.claude/settings.local.json` has a `hooks.PreToolUse` entry registering the script for `Bash`-matched calls.
+- `CLAUDE.md` mentions the pre-push hook, where it lives, and how to bypass.
+- `pnpm run preflight` passes locally (committed state).
+- Hook passes the smoke test on this very PR (the spec folder is present, so push proceeds; if the spec were missing, push would block).
+- All PR checks green.

--- a/specs/013-pin-pnpm-action-and-pre-push-hook/tasks.md
+++ b/specs/013-pin-pnpm-action-and-pre-push-hook/tasks.md
@@ -1,0 +1,15 @@
+# Tasks — 013-pin-pnpm-action-and-pre-push-hook
+
+- [x] T001: Resolve `pnpm/action-setup@v4` → annotated tag → commit SHA `b906affcce14559ad1aafd4ab0e942779e9f58b1` via `gh api`
+- [x] T002: Pin `pnpm/action-setup@<sha> # v4` in `.github/workflows/ci.yml`
+- [x] T003: Pin `pnpm/action-setup@<sha> # v4` in `.github/workflows/pr-guard.yml`
+- [x] T004: Update `docs_pallete_maker/project/devops/vercel-cd.md` to note pnpm/action-setup is now SHA-pinned (closes the third-party-action exception)
+- [x] T005: Write `.claude/hooks/check-feature-memory-on-push.sh` with stdin-JSON parsing, git-push regex, feature-memory invocation, exit-2-on-fail
+- [x] T006: `chmod +x` the hook script
+- [x] T007: Add `hooks.PreToolUse` block to `.claude/settings.local.json` referencing the script via `$CLAUDE_PROJECT_DIR`
+- [x] T008: Smoke-test the hook with fake JSON for both push and non-push cases (both exit 0 expected here since branch has no diff yet against origin/main pre-commit)
+- [x] T009: Document the hook in `CLAUDE.md` «Важные правила» (location, restore-on-clone, emergency bypass)
+- [x] T010: `pnpm run preflight` passes (committed state)
+- [ ] T011: Push triggers the hook itself; this PR's spec 013 satisfies the gate so push proceeds
+- [ ] T012: All PR checks green (baseline-checks, guard, osv-scan, AI Review, Vercel)
+- [ ] T013: Merge PR after all checks COMPLETED + SUCCESSFUL per `feedback_never_merge_before_review.md`


### PR DESCRIPTION
## Summary

Two related infra fixes:

**A. Pin pnpm/action-setup to commit SHA** (closes Codex P3 finding from PR #14).
`pnpm/action-setup@v4` was the only third-party action still on a floating tag despite the README's SHA-pinning claim. Now pinned to `b906affcce14559ad1aafd4ab0e942779e9f58b1` in `.github/workflows/ci.yml` and `pr-guard.yml`. Docs in `docs_pallete_maker/project/devops/vercel-cd.md` updated to list it among pinned actions.

**C. Local Claude Code pre-push hook** (option C from earlier A+B+C structural-guardrails discussion).
After 5 consecutive PRs where the implementation agent forgot the `specs/<id>/` folder before push, A (memory) and B (preflight) proved insufficient. Hook lives in `.claude/hooks/check-feature-memory-on-push.sh` (gitignored, machine-local) and is registered in `.claude/settings.local.json` as a `PreToolUse` Bash hook that intercepts `git push` calls, runs `node scripts/check-feature-memory.mjs origin/main HEAD`, and exits 2 with a helpful message when product-path commits lack a spec folder. Documented in CLAUDE.md so future sessions on a new machine know how to restore it.

Spec 013: `specs/013-pin-pnpm-action-and-pre-push-hook/`.

## Test plan

- [x] `pnpm run preflight` passes (59/59 tests, build, format)
- [x] Hook smoke-tested with synthetic JSON for both push and non-push commands
- [ ] CI green
- [ ] AI Review (Codex) pass
- [ ] PR Guard pass (this push depends on the hook NOT being active yet OR the spec being included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)