### PR TITLE
docs: 2-tier architecture, canonical ownership, fact sync

### DIFF
--- a/.github/workflows/ai-command-policy.yml
+++ b/.github/workflows/ai-command-policy.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           script: |
             const body = (context.payload.comment?.body || "").toLowerCase();
-            const defaults = { implementation: "claude", review: "gemini" };
+            const defaults = { implementation: "claude", review: "codex" };
             const trustedAssociations = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
 
             let kind = null;

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -37,7 +37,7 @@ concurrency:
 
 jobs:
   ai-review:
-    # Gate-based path: gemini and codex (and unset default → gemini)
+    # Gate-based path: gemini and codex (and unset default → codex)
     if: >
       (
         github.event_name == 'workflow_dispatch' ||
@@ -75,7 +75,7 @@ jobs:
           set -euo pipefail
           selected="${{ vars.AI_REVIEW_AGENT }}"
           if [ -z "$selected" ]; then
-            selected="gemini"
+            selected="codex"
           fi
 
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
@@ -83,11 +83,12 @@ jobs:
           else
             # All three backends (gemini, codex, claude) reject bot-posted
             # trigger comments on pull_request events, so the gate stays in
-            # skip mode. Gemini Code Assist auto-reviews on PR open; manual
-            # recovery uses `pnpm run review:switch` or a trusted human
-            # trigger comment. See docs_pallete_maker/project/devops/
-            # review-trigger-automation.md for the full constraint matrix
-            # and proposed automation.
+            # skip mode. Only Gemini Code Assist auto-reviews on PR open;
+            # codex and claude require a human-authored trigger on every
+            # review (open + synchronize). Manual recovery uses
+            # `pnpm run review:switch` or a trusted human trigger comment.
+            # See docs_pallete_maker/project/devops/review-trigger-automation.md
+            # for the full constraint matrix and proposed automation.
             trigger_mode="skip"
           fi
 

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -53,10 +53,10 @@ through Vercel without relying on hidden session memory.
   Owns architecture, orchestration, CI/CD health, and repository memory, and
   is the default implementation agent. Runs from the user's local Claude Code
   terminal session and can dispatch other local agents via CLI when needed.
-- Gemini
-  Default review backend on GitHub pull requests via Gemini Code Assist.
 - Codex
-  Optional implementation and review agent behind explicit repository variable override.
+  Current default review backend via `@codex review` on PR comments (switched from Gemini on 2026-04-17). See `docs_pallete_maker/project/devops/ai-orchestration-protocol.md` for the full routing contract.
+- Gemini
+  Alternative review backend via Gemini Code Assist GitHub App; switch with `pnpm run review:switch -- --to gemini`.
 - GitHub Actions + Vercel
   Execute required checks, review normalization, previews, and production
   deployment.
@@ -76,8 +76,9 @@ through Vercel without relying on hidden session memory.
 
 ## macOS Local Runner Contract
 
-- Local orchestration is repository-owned and documented in
-  `docs_pallete_maker/project/devops/macos-local-runners.md`.
+- Local orchestration is repository-owned. Helper scripts live in `scripts/`
+  (`new-worktree.mjs`, `set-implementation-agent.mjs`,
+  `start-implementation-worker.mjs`, `publish-branch.mjs`).
 - Local agent selection state is stored under `.claude/` and is gitignored.
 - Local worktrees are created inside `<repoRoot>/.claude/worktrees/<slug>/`
   so they stay inside the repository and do not pollute the user's

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,10 @@
 ## What Is pallete-maker?
 
 **pallete-maker** is a personal color palette creator. It lets a user pick a
-base color, build a harmonious palette of up to 10 colors using LCH-based
-harmony rules, preview the result on a grid, and export it as a PNG image.
+base color, build a harmonious palette of up to **15 colors (12 chromatic + 3
+achromatic; constants `MAX_TOTAL`, `MAX_CHROMATIC` in `src/scripts/harmony.mjs`)**
+using LCH-based harmony rules, preview the result on a grid, and export it as a
+PNG image.
 
 **Current implementation:** static single-file web app
 **Core dependencies:** chroma-js 2.4.2 (LCH harmony), html2canvas 1.4.1 (PNG export)
@@ -72,10 +74,11 @@ pallete-maker/
   - `AI_REVIEW_AGENT`
 - Default policy for this repository is:
   - implementation: `claude`
-  - review: `gemini`
+  - review: `codex` (switched from `gemini` on 2026-04-17; see `docs_pallete_maker/project/devops/ai-orchestration-protocol.md` for the canonical description)
 - Claude is the default implementation agent because it owns architecture, orchestration, CI/CD health, and repository memory, and is driven from the user's local Claude Code terminal session.
-- Gemini is the default review backend because it runs natively on GitHub pull requests via the Gemini Code Assist GitHub App.
-- Codex is available as an alternative review or implementation backend behind an explicit repository variable override.
+- Codex is the current default review backend via `@codex review` triggers on PR comments.
+- Gemini review stays wired via Gemini Code Assist GitHub App; switch with `pnpm run review:switch -- --to gemini`.
+- Claude review workflow (`claude-review.yml`) is **currently non-operational** (dead code pending cleanup PR; no `ANTHROPIC_API_KEY` configured, local runner rolled back).
 
 ## Review Guidelines
 
@@ -105,8 +108,10 @@ Changes must keep `pnpm run build` producing a deployable `dist/index.html` arti
 
 ### 4. One worker equals one worktree
 
-Do not run parallel implementation work in the main checkout. Use the local
-macOS runner flow from `docs_pallete_maker/project/devops/macos-local-runners.md`.
+Do not run parallel implementation work in the main checkout. Worktrees live
+under `<repoRoot>/.claude/worktrees/<slug>/` and are created via
+`scripts/new-worktree.mjs`. Local orchestration state is gitignored under
+`.claude/`.
 
 ### 5. Gemini review config is repository-owned
 
@@ -118,22 +123,12 @@ contract.
 
 Avoid adding more fixed-size offsets and viewport hacks unless strictly necessary. Prefer layout systems that can survive later migration to a modular frontend app.
 
-### 7. Auto-routing for orchestration capabilities
+### 7. Propose orchestration before non-trivial tasks
 
-Before executing a non-trivial task, evaluate whether any orchestration capability available to you (oh-my-claudecode (OMC) modes, subagents, multi-agent council, parallel execution, verification loops, etc.) is a better fit than a single-pass implementation. If one is, **propose it to the user in one short sentence with justification before starting**. Do not auto-launch; wait for user consent.
+Before a non-trivial task (multi-file change, refactor, research, verification loop, parallelizable work, unclear-cause debugging), propose the best-fit orchestration capability available to you in one short sentence with justification. Wait for user consent. Skip for trivial tasks (rename, one-line fix, quick question).
 
-Non-trivial triggers (any one):
-
-- Multi-file change, refactor, or migration
-- Codebase research where the answer is not obvious
-- Task that benefits from a verification / QA cycle
-- Parallelizable work (several independent subtasks)
-- Long-running autonomous work ("don't stop until done")
-- Debugging with unclear cause, tracing, or competing hypotheses
-
-Representative modes / agents to consider (Claude Code users have OMC modes like `/plan`, `/ralph`, `/ultrawork`, `/autopilot`, `/team`, `/trace`, `/debug`, `/ask` and subagents such as `executor`, `architect`, `critic`, `code-reviewer`, `debugger`, `tracer`, `verifier`, `planner`, `security-reviewer`, `test-engineer`, `explorer`, `designer`, `writer`). Codex / Gemini / other agents should propose their equivalent capabilities (planning modes, parallel task runners, review councils, etc.) before starting non-trivial work.
-
-Skip the proposal for trivial tasks: rename, one-line fix, simple question, quick status check. Minimal-friction principle — do not nag on small things.
+Claude Code specifics (OMC modes, subagents): see `CLAUDE.md § OMC orchestration`.
+Codex / Gemini / other agents: propose your equivalent capabilities (planning modes, parallel runners, review councils) before starting.
 
 ### 8. Always verify active branch and target refs before answering repo-state questions
 
@@ -147,13 +142,16 @@ workflow behavior:
 
 ## Reading Route — Implementing a Change
 
-1. `.specify/memory/constitution.md`
-2. `docs_pallete_maker/README.md`
-3. `docs_pallete_maker/project-idea.md`
-4. `docs_pallete_maker/project/frontend/frontend-docs.md`
-5. `docs_pallete_maker/project/devops/ai-orchestration-protocol.md`
-6. `docs_pallete_maker/project/devops/ai-pr-workflow.md`
-7. `specs/<feature-id>/spec.md`
-8. `specs/<feature-id>/plan.md`
-9. `specs/<feature-id>/tasks.md`
-10. Relevant app files and scripts
+This is the canonical reading order. `docs_pallete_maker/README.md` is a topical index (grouped by theme), not a reading order — defer to this list.
+
+1. `.specify/memory/constitution.md` — non-negotiable process rules
+2. `docs_pallete_maker/project-idea.md` — product facts (palette size, product state)
+3. `docs_pallete_maker/project/frontend/frontend-docs.md` — frontend architecture, grid, harmony, export
+4. `docs_pallete_maker/project/devops/ai-orchestration-protocol.md` — agent routing, default policy, review backends
+5. `docs_pallete_maker/project/devops/ai-pr-workflow.md` — PR gates and merge rules
+6. `docs_pallete_maker/project/devops/review-contract.md` — what each review backend produces
+7. `docs_pallete_maker/project/devops/review-trigger-automation.md` — why bot-posted triggers are rejected, active Tier 1
+8. `docs_pallete_maker/project/devops/delivery-playbook.md` — preview + production smoke
+9. `docs_pallete_maker/project/devops/vercel-cd.md` — Vercel deploy contract and security headers
+10. `specs/<feature-id>/spec.md`, `plan.md`, `tasks.md` — active feature
+11. Relevant app files and scripts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # pallete-maker
 
-Персональный инструмент для создания цветовых палитр: выбор базового цвета, построение гармоничной палитры до 10 цветов с проверкой LCH-гармоний и экспортом в PNG.
+Персональный инструмент для создания цветовых палитр: выбор базового цвета, построение гармоничной палитры до 15 цветов (12 хроматических + 3 ахроматических) с проверкой LCH-гармоний и экспортом в PNG.
 
 ## Текущий стек
 
@@ -10,7 +10,7 @@
 - Vercel Git integration для preview и production deploy
 - GitHub Actions для CI, guard и AI review orchestration
 - `.specify/`, `docs_pallete_maker/` и `specs/` как repository memory
-- Gemini Code Assist как default review backend
+- Codex как default review backend (см. `docs_pallete_maker/project/devops/ai-orchestration-protocol.md`)
 
 ## Важные правила
 
@@ -25,6 +25,8 @@
 - Локальный pre-push hook: `.claude/hooks/check-feature-memory-on-push.sh` (зарегистрирован в `.claude/settings.local.json` как PreToolUse на Bash) блокирует `git push`, если committed product-path changes требуют `specs/<id>/{spec,plan,tasks}.md` и спека нет. `.claude/` gitignored — на новой машине восстановить вручную из spec 013. Emergency bypass: закомментировать hook в `.claude/settings.local.json` или запушить из обычного терминала.
 - Не ломай `pnpm run build`: проект должен оставаться deployable как статический сайт
 - При review фокусируйся на mobile grid reflow, harmony rules correctness, PNG export safety, RU-строках и maintainability
+- Не создавай абстракции на один use-case. Если функция используется в одном месте, она не нуждается в конфигурируемости, plugin-интерфейсе или generic-параметрах. Добавляй обобщение только когда появляется второй реальный потребитель.
+- Для multi-step задач без отдельной спеки (рутинные 3-5 шагов: CDN-обновление, refactor одного модуля, миграция конфига) перед началом выпиши план: `шаг -> verify-условие`. Не делай молча и не запускай полный `/plan` ради 3 шагов.
 
 ## OMC orchestration (auto-routing)
 
@@ -62,4 +64,6 @@
 - PR loop: `docs_pallete_maker/project/devops/ai-pr-workflow.md`
 - Review contract: `docs_pallete_maker/project/devops/review-contract.md`
 - Review trigger automation: `docs_pallete_maker/project/devops/review-trigger-automation.md`
+- Delivery playbook: `docs_pallete_maker/project/devops/delivery-playbook.md`
 - Vercel CD: `docs_pallete_maker/project/devops/vercel-cd.md`
+- ADR index: `docs_pallete_maker/adr/README.md`

--- a/docs_pallete_maker/README.md
+++ b/docs_pallete_maker/README.md
@@ -1,34 +1,28 @@
 # pallete-maker Docs Map
 
-`docs_pallete_maker/` is the durable memory layer for this repository.
+> Topical index. For the reading order, see `AGENTS.md § Reading Route`.
 
-## What belongs here
+`docs_pallete_maker/` is the durable memory layer for this repository. Entry points are `CLAUDE.md` (Claude-specific) and `AGENTS.md` (universal); this directory holds content they link into.
 
-- stable product context
-- frontend architecture decisions
-- delivery and deployment rules
-- review and orchestration contracts
-- ADRs and operating playbooks
+## Structure by topic
 
-## Main reading order
+**Product**
 
-1. `.specify/memory/constitution.md`
-2. `docs_pallete_maker/project-idea.md`
-3. `docs_pallete_maker/project/frontend/frontend-docs.md`
-4. `docs_pallete_maker/project/devops/ai-orchestration-protocol.md`
-5. `docs_pallete_maker/project/devops/ai-pr-workflow.md`
-6. `docs_pallete_maker/project/devops/review-trigger-automation.md`
-7. `specs/<feature-id>/spec.md`
-8. `specs/<feature-id>/plan.md`
-9. `specs/<feature-id>/tasks.md`
+- `project-idea.md` — product facts (palette size, composition, roadmap). **Canonical source** for product facts.
 
-## Structure
+**Frontend**
 
-- `adr/`
-  Architecture decision records and cross-cutting technical choices
-- `project-idea.md`
-  Product goals and current roadmap
-- `project/frontend/`
-  Frontend architecture and UI behavior notes
-- `project/devops/`
-  CI/CD, review, orchestration, and delivery workflow
+- `project/frontend/frontend-docs.md` — grid columns, harmony algorithm, build pipeline, accessibility.
+
+**Delivery & CI**
+
+- `project/devops/ai-orchestration-protocol.md` — agent routing, default review backend, native execution surfaces. **Canonical source** for review policy.
+- `project/devops/ai-pr-workflow.md` — PR gates and merge rules.
+- `project/devops/review-contract.md` — what each backend produces; severity rules.
+- `project/devops/review-trigger-automation.md` — bot-trigger rejection (Tier 1 active; design for Tier 2/3 in ADR).
+- `project/devops/delivery-playbook.md` — preview validation and production smoke.
+- `project/devops/vercel-cd.md` — Vercel deploy contract, security headers, supply-chain hygiene.
+
+**Decisions**
+
+- `adr/` — architecture decision records and cross-cutting choices.

--- a/docs_pallete_maker/adr/0001-review-trigger-design.md
+++ b/docs_pallete_maker/adr/0001-review-trigger-design.md
@@ -1,0 +1,68 @@
+# ADR 0001 — Review Trigger Automation (Tier 2/3 design)
+
+**Status:** Design only. Not adopted. Tier 1 (`pnpm run review:switch`) is the active mitigation — see `docs_pallete_maker/project/devops/review-trigger-automation.md`.
+
+**Date:** 2026-04-18 (extracted from `review-trigger-automation.md` during docs consolidation)
+
+**Context:** All three supported review backends reject bot-posted trigger comments. Tier 1 (manual wrapper) is live and sufficient for current volume. This ADR captures the broader automation options so a future spec can adopt one without re-researching the problem.
+
+## Tier 2 — Local git post-push hook (semi-automatic)
+
+A husky-managed `post-push` hook that runs locally after every `git push` to a branch with an open PR. It detects the PR number via `gh pr view --json number` and posts the appropriate trigger comment using local `gh`.
+
+- Pros: fully automatic for local developer pushes.
+- Cons: does NOT run when agents or CI push (hooks are local only); needs husky wiring.
+
+## Tier 3 — GitHub Actions workflow with user PAT (most coverage)
+
+A new workflow listens on `pull_request: synchronize` and posts the trigger comment via `gh pr comment` using a repository secret containing a fine-grained PAT scoped to this repo.
+
+Sketch:
+
+```yaml
+name: Review Trigger
+on:
+  pull_request:
+    types: [synchronize]
+
+jobs:
+  post-trigger:
+    if: >
+      github.event.pull_request.head.repo.full_name == github.repository
+      && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve trigger comment for backend
+        id: agent
+        run: |
+          agent="${{ vars.AI_REVIEW_AGENT }}"
+          case "${agent:-codex}" in
+            codex)  echo "trigger=@codex review"  >> "$GITHUB_OUTPUT" ;;
+            gemini) echo "trigger=/gemini review" >> "$GITHUB_OUTPUT" ;;
+            claude) echo "trigger=@claude review once" >> "$GITHUB_OUTPUT" ;;
+          esac
+      - name: Post trigger comment as repo owner
+        env:
+          GH_TOKEN: ${{ secrets.USER_REVIEW_PAT }}
+        run: |
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --body "${{ steps.agent.outputs.trigger }}" \
+            --repo "${{ github.repository }}"
+```
+
+- Pros: fully automatic for any push source (human, agent, CI); no local setup required on every dev machine.
+- Cons: introduces a PAT secret in the repo — must be fine-grained, scoped to `Pull requests: Write` on this single repo, and rotated annually.
+
+## PAT Security Requirements (if adopting Tier 3)
+
+- Fine-grained PAT, not classic token.
+- Resource owner: repo owner only.
+- Repository access: `kiaquila/pallete-maker` only (Selected repositories, not All).
+- Permissions: `Pull requests: Write`, `Contents: Read`. Nothing else.
+- Expiration: 1 year maximum. Calendar reminder for rotation.
+- Store in GitHub repo secret `USER_REVIEW_PAT`. Never log or echo.
+- Revoke immediately on any suspicious activity in the repo.
+
+## Recommendation
+
+Adopt Tier 1 now (active). Adopt Tier 3 when recurring friction from manual retriggers outweighs the PAT security posture review. Tier 2 is optional for developers who prefer local-only automation.

--- a/docs_pallete_maker/adr/README.md
+++ b/docs_pallete_maker/adr/README.md
@@ -3,10 +3,15 @@
 This folder stores durable cross-cutting decisions that should survive
 individual feature PRs.
 
-Examples:
+## Index
+
+- `0001-review-trigger-design.md` — Tier 2/3 automation design for review-trigger bypass (Tier 1 active; Tier 2/3 not adopted).
+
+## When to add an ADR
 
 - framework migrations
 - storage or persistence strategy
 - deployment model changes
 - palette architecture changes
 - agent orchestration changes that affect repository policy
+- any design that's captured in a devops doc but not currently adopted (extract as ADR to keep the devops doc about active behavior)

--- a/docs_pallete_maker/project-idea.md
+++ b/docs_pallete_maker/project-idea.md
@@ -6,9 +6,11 @@
 
 - browse a fixed palette of 51 curated colors and pick a base color
 - automatically see which colors are compatible based on an internal harmony algorithm (group + temperature rules)
-- assemble a palette of up to 14 colors (11 chromatic + 3 achromatic)
+- assemble a palette of **up to 15 colors** (`MAX_TOTAL = 15`, `MAX_CHROMATIC = 12` in `src/scripts/harmony.mjs`; 12 chromatic + 3 achromatic)
 - preview the selection in a bottom drawer, sorted achromatics-first
 - export the palette as a PNG image via html2canvas
+
+> This file is the canonical source of truth for product facts (palette size, composition). Other docs reference this.
 
 ## Current Product State
 
@@ -25,7 +27,7 @@ The repository now follows the standard delivery path:
 
 1. PR-only changes
 2. required checks in GitHub
-3. AI review routing through repository policy with Gemini as the default reviewer
+3. AI review routing through repository policy (current default: Codex; see `project/devops/ai-orchestration-protocol.md`)
 4. Vercel preview deploys on PR
 5. Vercel production deploys on merge to `main`
 6. repository memory through `.specify/`, `docs_pallete_maker/`, and `specs/`

--- a/docs_pallete_maker/project/devops/ai-orchestration-protocol.md
+++ b/docs_pallete_maker/project/devops/ai-orchestration-protocol.md
@@ -1,5 +1,7 @@
 # AI Orchestration Protocol
 
+> Audience: all agents. **Canonical source** for: agent routing, default review backend, supported agents, review normalization. Other docs reference this. Prereq: `.specify/memory/constitution.md`. Next: `ai-pr-workflow.md`.
+
 ## Canonical Delivery Contract
 
 `pallete-maker` uses a PR-only delivery model.
@@ -27,23 +29,26 @@ Agent routing is controlled by repository variables:
 - `codex`
 - `gemini`
 
-Default policy in this repository:
+Default policy in this repository (canonical):
 
 - implementation: `claude`
-- review: `gemini`
+- review: `codex` (switched from `gemini` on 2026-04-17)
 
 Claude is the canonical default implementation agent because it owns
 architecture, orchestration, CI/CD health, and repository memory for this
 repository, and is driven from the user's local Claude Code terminal session.
 
-Gemini is the canonical default review backend because it runs natively on
-GitHub pull requests via the Gemini Code Assist GitHub App.
+Codex is the current default review backend. It runs natively on GitHub pull
+requests via the ChatGPT Codex connector, triggered by `@codex review` comments
+from trusted human actors.
 
-Codex is available as an alternative review or implementation backend behind
-an explicit `AI_REVIEW_AGENT=codex` or `AI_IMPLEMENTATION_AGENT=codex` override.
+Gemini is available as an alternative review backend via the Gemini Code Assist
+GitHub App. Switch with `pnpm run review:switch -- --to gemini`.
 
-Claude review is a third-tier option behind an explicit `AI_REVIEW_AGENT=claude`
-override and still requires `ANTHROPIC_API_KEY` when used via GitHub Actions.
+Claude review (`claude-review.yml` workflow) is **currently non-operational**:
+the workflow file remains in the repository as dead code pending a cleanup PR,
+but `ANTHROPIC_API_KEY` is not configured and the local Claude runner was
+rolled back. Do not select `AI_REVIEW_AGENT=claude` until this is restored.
 
 ## Local macOS Orchestration
 
@@ -70,12 +75,13 @@ repository and do not pollute the user's `~/projects/` directory.
 
 Review normalization behavior:
 
-- `gemini` is the default review backend and auto-reviews on PR open
+- `codex` is the current default review backend; `@codex review` from a trusted
+  human posts a native PR review
 - pull-request `AI Review` runs support `codex`, `gemini`, and `claude`
 - manual Gemini and Codex review comments stay native-only to avoid canceling
   the PR-linked `AI Review` check
 - trusted human review commands dispatch the shared `AI Review` gate via
-  `workflow_dispatch` only for `claude`
+  `workflow_dispatch` only for `claude` (currently non-operational, see above)
 - the gate may reuse an existing same-head native review when a PR-linked
   `AI Review` run is rerun
 

--- a/docs_pallete_maker/project/devops/ai-pr-workflow.md
+++ b/docs_pallete_maker/project/devops/ai-pr-workflow.md
@@ -30,10 +30,16 @@ Summary (details in `review-contract.md` and `ai-orchestration-protocol.md`):
 - `AI Review` is the normalized required check regardless of the backend.
 - Reviewer selection comes only from `AI_REVIEW_AGENT` (current default: `codex`).
 - Low-severity-only findings are advisory and non-blocking.
-- After a new push, a human must post the native trigger comment
-  (`@codex review`, `/gemini review`, or `@claude review once`), or run
-  `pnpm run review:switch -- --to <agent>`. Bot-posted triggers are rejected
-  by all three backends — see `review-trigger-automation.md`.
+- **Human trigger required for Codex on EVERY review**, including the first
+  review on PR open — Codex does not auto-review. (Only Gemini Code Assist
+  auto-reviews on `opened` / `ready_for_review`.) The gate runs with
+  `trigger_mode=skip` on `pull_request` events and polls for an existing
+  same-head review, so without a human trigger it waits until timeout.
+- After a new push on an already-open PR, a human must post the native
+  trigger comment again (`@codex review`, `/gemini review`, or
+  `@claude review once`), or run `pnpm run review:switch -- --to <agent>`.
+  Bot-posted triggers are rejected by all three backends — see
+  `review-trigger-automation.md`.
 
 ## Merge-Ready Definition
 

--- a/docs_pallete_maker/project/devops/ai-pr-workflow.md
+++ b/docs_pallete_maker/project/devops/ai-pr-workflow.md
@@ -1,6 +1,8 @@
 # AI Pull Request Workflow
 
-This is the canonical PR loop for `pallete-maker`.
+> Audience: all agents. **Canonical source** for: PR-specific gates and merge rules. Prereq: `.specify/memory/constitution.md` (Standard Feature Loop), `ai-orchestration-protocol.md` (agent routing). Next: `review-contract.md`.
+
+This doc covers PR-specific gates. The 10-step Standard Feature Loop lives in `.specify/memory/constitution.md § Standard Feature Loop` — do not duplicate here.
 
 ## Roles
 
@@ -11,24 +13,6 @@ This is the canonical PR loop for `pallete-maker`.
 - Vercel provides preview deployments for PRs and production deploy on merge to
   `main`.
 - A human remains the final merge authority.
-
-## Standard Loop
-
-1. Start from current `main`.
-2. Create or update one active `specs/<feature-id>/` folder.
-3. Create an isolated macOS worktree for the task under
-   `<repoRoot>/.claude/worktrees/<slug>/`.
-4. Select the implementation and review agents for the branch.
-5. Generate the implementation prompt from repository memory.
-6. Implement only the scoped change on that branch.
-7. Update `tasks.md`, docs, and tests or validation notes in the same PR.
-8. Open or update the same PR.
-9. Wait for:
-   - `baseline-checks`
-   - `guard`
-   - `AI Review`
-   - healthy Vercel preview deployment
-10. Keep fixing the same branch until only human approval and merge remain.
 
 ## Hard Gates
 
@@ -41,22 +25,15 @@ This is the canonical PR loop for `pallete-maker`.
 
 ## Review Contract
 
-- Reviewer selection comes only from `AI_REVIEW_AGENT`.
-- Supported review backends are `gemini`, `codex`, and `claude`.
+Summary (details in `review-contract.md` and `ai-orchestration-protocol.md`):
+
 - `AI Review` is the normalized required check regardless of the backend.
+- Reviewer selection comes only from `AI_REVIEW_AGENT` (current default: `codex`).
 - Low-severity-only findings are advisory and non-blocking.
-- With no repository override, the pull-request gate defaults to `gemini`.
-- Auto-retrigger on `synchronize` is not supported for any backend: all
-  three reject bot-posted trigger comments. The gate therefore stays in
-  `trigger_mode=skip` on every `pull_request` event and passively waits
-  for a same-head native review.
-- Initial PR review is covered by Gemini Code Assist's on-open auto-review.
-  After a new push on an already-open PR, a human must post the appropriate
-  native trigger comment (`/gemini review`, `@codex review`, or
-  `@claude review once`), or run `pnpm run review:switch -- --to <agent>`
-  to flip backends and trigger the new reviewer in one shot.
-- Manual Gemini and Codex review commands stay native-only so they do not
-  cancel the PR-linked `AI Review` check.
+- After a new push, a human must post the native trigger comment
+  (`@codex review`, `/gemini review`, or `@claude review once`), or run
+  `pnpm run review:switch -- --to <agent>`. Bot-posted triggers are rejected
+  by all three backends — see `review-trigger-automation.md`.
 
 ## Merge-Ready Definition
 

--- a/docs_pallete_maker/project/devops/delivery-playbook.md
+++ b/docs_pallete_maker/project/devops/delivery-playbook.md
@@ -1,5 +1,7 @@
 # Delivery Playbook
 
+> Audience: all agents. Canonical source for: preview validation checklist, merge rule, production smoke. Prereq: `ai-pr-workflow.md`. Next: `vercel-cd.md` (deploy contract).
+
 This playbook covers preview validation before merge and production smoke after
 merge.
 

--- a/docs_pallete_maker/project/devops/review-contract.md
+++ b/docs_pallete_maker/project/devops/review-contract.md
@@ -4,7 +4,12 @@
 
 ## Backend Trigger Constraints (summary)
 
-All three backends reject bot-posted trigger comments on `pull_request: synchronize`; a human-authored trigger is required on every new push. Full backend matrix and mitigation Tiers: see `review-trigger-automation.md`. Canonical recovery: `pnpm run review:switch -- --to <agent>`.
+All three backends reject bot-posted trigger comments. A human-authored trigger is required:
+
+- on **every new push** (`pull_request: synchronize`) for any backend, and
+- on **PR open** for `codex` and `claude` — only Gemini Code Assist auto-reviews on `opened` / `ready_for_review`. With `AI_REVIEW_AGENT=codex` (current default), the initial `AI Review` run waits until timeout unless a human posts `@codex review` right after opening the PR.
+
+Full backend matrix and mitigation Tiers: see `review-trigger-automation.md`. Canonical recovery: `pnpm run review:switch -- --to <agent>`.
 
 ## Codex Review (current default)
 

--- a/docs_pallete_maker/project/devops/review-contract.md
+++ b/docs_pallete_maker/project/devops/review-contract.md
@@ -1,41 +1,14 @@
 # Review Contract
 
-## Backend Trigger Constraints
+> Audience: all agents. **Canonical source** for: per-backend review output format, severity rules, `AI_REVIEW_OUTCOME` schema. Prereq: `ai-orchestration-protocol.md` (agent routing). Sibling: `review-trigger-automation.md` (trigger mechanics).
 
-All three supported review backends require a **human-authored** trigger
-on `pull_request: synchronize` events. Bot-posted trigger comments from
-GitHub Actions (`github-actions[bot]`) are rejected silently or with an
-explicit error by every backend:
+## Backend Trigger Constraints (summary)
 
-- **Gemini** — `gemini-code-assist[bot]` silently ignores bot-posted
-  `/gemini review` comments; the gate times out after 20 minutes.
-- **Codex** — the connector replies "trigger did not come from a
-  connected human Codex account" and the `AI Review` gate fails fast.
-- **Claude** — `claude-review.yml` gates on `author_association in
-(OWNER, MEMBER, COLLABORATOR)` and drops anything authored by a bot.
+All three backends reject bot-posted trigger comments on `pull_request: synchronize`; a human-authored trigger is required on every new push. Full backend matrix and mitigation Tiers: see `review-trigger-automation.md`. Canonical recovery: `pnpm run review:switch -- --to <agent>`.
 
-Gemini Code Assist's on-open auto-review (on `opened` and `ready_for_review`)
-covers the initial review for free, but every new push on an already-open PR
-needs a manual trigger. The canonical recovery path is
-`pnpm run review:switch -- --to <agent>`, which flips the repository
-variable, posts the correct native trigger comment as the current `gh`
-user (human-authored, therefore trusted), and reruns the most recent
-failed `AI Review` job.
+## Codex Review (current default)
 
-See `docs_pallete_maker/project/devops/review-trigger-automation.md` for the full
-backend matrix.
-
-## Gemini Review
-
-- Default review backend for `pallete-maker`
-- Native GitHub PR review surface from `gemini-code-assist[bot]`
-- Inline findings are expected to carry `Critical`, `High`, `Medium`, or `Low`
-- `Low`-only findings are advisory
-- `Critical`, `High`, and `Medium` findings block merge
-
-## Codex Review
-
-- Optional fallback review backend, used when `AI_REVIEW_AGENT=codex`
+- Current default review backend, used when `AI_REVIEW_AGENT=codex`
 - Native GitHub PR review surface from `chatgpt-codex-connector[bot]`
 - Inline findings must carry `P0` to `P3`
 - `P3`-only findings are advisory
@@ -48,11 +21,23 @@ backend matrix.
 - If the timeline lookup is unavailable, the gate logs a warning and
   fails closed by waiting for formal review only.
 
-## Claude Review
+## Gemini Review
 
-- Third-tier optional review backend, used when `AI_REVIEW_AGENT=claude`
+- Alternative review backend, used when `AI_REVIEW_AGENT=gemini`
+- Native GitHub PR review surface from `gemini-code-assist[bot]`
+- Inline findings are expected to carry `Critical`, `High`, `Medium`, or `Low`
+- `Low`-only findings are advisory
+- `Critical`, `High`, and `Medium` findings block merge
+
+## Claude Review (currently non-operational)
+
+Retained for schema reference only. The `claude-review.yml` workflow is dead
+code pending cleanup; `ANTHROPIC_API_KEY` is not configured and the local
+runner was rolled back. Do not select `AI_REVIEW_AGENT=claude` until restored.
+
+Schema (when operational):
+
 - Triggered by a human posting `@claude review once` on the PR
-- Handled by the `claude-review.yml` workflow using `ANTHROPIC_API_KEY`
 - Final result is a top-level comment, not a formal GitHub review state
 - The comment must start with:
 

--- a/docs_pallete_maker/project/devops/review-trigger-automation.md
+++ b/docs_pallete_maker/project/devops/review-trigger-automation.md
@@ -10,7 +10,7 @@ All three supported review backends reject bot-posted trigger comments on `pull_
 - **Gemini** — `gemini-code-assist[bot]` silently ignores bot-posted `/gemini review` comments.
 - **Claude** — `claude-review.yml` gates on `author_association in (OWNER, MEMBER, COLLABORATOR)` and drops bot-authored comments.
 
-Gemini Code Assist auto-reviews PRs on `opened` and `ready_for_review`, which covers the first review on PR creation. Every subsequent push to an already-open PR requires a human-authored trigger.
+Only Gemini Code Assist auto-reviews PRs on `opened` / `ready_for_review`. With `AI_REVIEW_AGENT=codex` (current default) or `claude`, **even the first review on PR open requires a human-authored trigger** — the gate runs with `trigger_mode=skip` on `pull_request` events and polls for an existing same-head native review, so without a human trigger it waits until timeout. Every subsequent push likewise requires a human-authored trigger for all three backends.
 
 ## Core Insight
 

--- a/docs_pallete_maker/project/devops/review-trigger-automation.md
+++ b/docs_pallete_maker/project/devops/review-trigger-automation.md
@@ -1,89 +1,41 @@
 # Review Trigger Automation
 
+> Audience: all agents. **Canonical source** for: bot-trigger rejection matrix, Tier 1 (active) recovery path. Tier 2/3 design: see `docs_pallete_maker/adr/0001-review-trigger-design.md`.
+
 ## Problem
 
 All three supported review backends reject bot-posted trigger comments on `pull_request: synchronize` events:
 
-- **Gemini** — `gemini-code-assist[bot]` silently ignores bot-posted `/gemini review` comments.
 - **Codex** — the connector replies `trigger did not come from a connected human Codex account`.
+- **Gemini** — `gemini-code-assist[bot]` silently ignores bot-posted `/gemini review` comments.
 - **Claude** — `claude-review.yml` gates on `author_association in (OWNER, MEMBER, COLLABORATOR)` and drops bot-authored comments.
 
-Gemini Code Assist auto-reviews PRs on `opened` and `ready_for_review`, which covers the first review on PR creation. But every subsequent push to an already-open PR requires a human to post the trigger comment. This creates recurring friction, especially when agents (Claude Code, Codex CLI) push updates to PR branches.
+Gemini Code Assist auto-reviews PRs on `opened` and `ready_for_review`, which covers the first review on PR creation. Every subsequent push to an already-open PR requires a human-authored trigger.
 
 ## Core Insight
 
 The backends check whether the comment's `author_association` is a human role (`OWNER`, `MEMBER`, `COLLABORATOR`) and whether the posting account is a human GitHub account — NOT whether the auth is a PAT vs GitHub App token. A fine-grained Personal Access Token (PAT) belonging to the repository owner IS treated as a human trigger.
 
-This means automation is possible by having GitHub Actions post trigger comments using a user PAT instead of the default `github.token` (which authenticates as `github-actions[bot]`).
+## Tier 1 — Manual local wrapper (active, zero secrets)
 
-## Three Tiers of Automation
+Canonical recovery path. Use on every push that needs a re-review:
 
-### Tier 1 — Manual local wrapper (baseline, zero new secrets)
-
-Existing `pnpm run review:switch -- --to <agent>` already posts the correct trigger comment using the local `gh` CLI auth (human-authored). A complementary `pnpm run review:retrigger` that only posts the current agent's trigger comment (without flipping the variable) would cover the "just rerun the review on my latest push" case.
-
-- Pros: no secrets; purely local; works today with minor script.
-- Cons: manual invocation after every push.
-
-### Tier 2 — Local git post-push hook (semi-automatic)
-
-A husky-managed `post-push` hook that runs locally after every `git push` to a branch with an open PR. It detects the PR number via `gh pr view --json number` and posts the appropriate trigger comment using local `gh`.
-
-- Pros: fully automatic for local developer pushes.
-- Cons: does NOT run when agents or CI push (hooks are local only); needs husky wiring.
-
-### Tier 3 — GitHub Actions workflow with user PAT (most coverage)
-
-A new workflow listens on `pull_request: synchronize` and posts the trigger comment via `gh pr comment` using a repository secret containing a fine-grained PAT scoped to this repo.
-
-Sketch:
-
-```yaml
-name: Review Trigger
-on:
-  pull_request:
-    types: [synchronize]
-
-jobs:
-  post-trigger:
-    if: >
-      github.event.pull_request.head.repo.full_name == github.repository
-      && github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    steps:
-      - name: Resolve trigger comment for backend
-        id: agent
-        run: |
-          agent="${{ vars.AI_REVIEW_AGENT }}"
-          case "${agent:-gemini}" in
-            gemini) echo "trigger=/gemini review" >> "$GITHUB_OUTPUT" ;;
-            codex)  echo "trigger=@codex review"  >> "$GITHUB_OUTPUT" ;;
-            claude) echo "trigger=@claude review once" >> "$GITHUB_OUTPUT" ;;
-          esac
-      - name: Post trigger comment as repo owner
-        env:
-          GH_TOKEN: ${{ secrets.USER_REVIEW_PAT }}
-        run: |
-          gh pr comment "${{ github.event.pull_request.number }}" \
-            --body "${{ steps.agent.outputs.trigger }}" \
-            --repo "${{ github.repository }}"
+```
+pnpm run review:switch -- --to <agent>
 ```
 
-- Pros: fully automatic for any push source (human, agent, CI); no local setup required on every dev machine.
-- Cons: introduces a PAT secret in the repo — must be fine-grained, scoped to `Pull requests: Write` on this single repo, and rotated annually.
+The script:
 
-## PAT Security Requirements (if adopting Tier 3)
+1. flips the `AI_REVIEW_AGENT` repository variable if different from current
+2. posts the correct native trigger comment (`@codex review`, `/gemini review`, `@claude review once`) using the local `gh` CLI auth — human-authored, therefore trusted
+3. reruns the most recent failed `AI Review` job on the current PR head
 
-- Fine-grained PAT, not classic token.
-- Resource owner: repo owner only.
-- Repository access: `kiaquila/pallete-maker` only (Selected repositories, not All).
-- Permissions: `Pull requests: Write`, `Contents: Read`. Nothing else.
-- Expiration: 1 year maximum. Calendar reminder for rotation.
-- Store in GitHub repo secret `USER_REVIEW_PAT`. Never log or echo.
-- Revoke immediately on any suspicious activity in the repo.
+A complementary `pnpm run review:retrigger` (not yet implemented) would skip step 1 for the "just rerun the current agent" case.
 
-## Recommendation
+## Tier 2 and Tier 3 (design, not adopted)
 
-Adopt Tier 1 now (minimal script change). Adopt Tier 3 when recurring friction from manual retriggers outweighs the PAT security posture review. Tier 2 is optional for developers who prefer local-only automation.
+A local post-push git hook (Tier 2) and a GitHub Actions workflow posting trigger comments via a fine-grained PAT (Tier 3) would provide broader automation coverage but introduce setup or secret-management cost. The full design and PAT security requirements are captured in:
 
-This is documentation of the constraint; the actual adoption of Tier 1/2/3 is out of scope for the rollback PR and will be handled by a future spec.
+- `docs_pallete_maker/adr/0001-review-trigger-design.md`
+
+Adopt when recurring friction from Tier 1 outweighs the PAT security posture review.

--- a/docs_pallete_maker/project/devops/vercel-cd.md
+++ b/docs_pallete_maker/project/devops/vercel-cd.md
@@ -1,5 +1,7 @@
 # Vercel CD
 
+> Audience: all agents. Canonical source for: Vercel deploy contract, security headers (CSP/HSTS/XFO), supply-chain hygiene (OSV, Dependabot, SHA-pinned actions). Prereq: `delivery-playbook.md`.
+
 ## Deploy Model
 
 This repository uses **Vercel Git integration** as the canonical CD layer.

--- a/docs_pallete_maker/project/frontend/frontend-docs.md
+++ b/docs_pallete_maker/project/frontend/frontend-docs.md
@@ -1,5 +1,7 @@
 # Frontend Docs
 
+> Audience: all agents. Canonical source for: grid columns, harmony algorithm, build pipeline, accessibility. Product facts (palette size) are in `docs_pallete_maker/project-idea.md`.
+
 ## Current Architecture
 
 The application is a static SPA with a modular source layout:
@@ -41,7 +43,7 @@ The picker grid displays all 51 colors of the fixed palette:
   Chartreuse → Emerald → Teal → Cobalt → Indigo → Violet → Fuchsia
 - each swatch is a `<button>` element (88px, `--swatch-outer` CSS var) showing a color circle, name, and HEX
 - dimmed (incompatible) cards carry `aria-disabled="true"` and `tabindex="-1"`
-- responsive columns: 3 (mobile ≥375) → 4 (≥480) → 6 (≥640) → 8 (≥1024) → 10 (≥1280)
+- responsive columns: 3 (mobile ≥375) → 4 (≥480) → 6 (≥640) → 8 (≥1024) → 11 (≥1280)
 - color selection state is ephemeral (no persistence)
 - DOM refs are cached on init in a `DOM` object; full grid rebuild on each state change
 - the achromatic White swatch uses `#FFFFFF` with a subtle neutral inner outline

--- a/specs/014-docs-2tier-consolidation/plan.md
+++ b/specs/014-docs-2tier-consolidation/plan.md
@@ -1,0 +1,74 @@
+# Plan 014 — Docs 2-tier Consolidation + Fact Sync
+
+## Approach
+
+Single-PR refactor in the `claude/silly-margulis-57ff15` worktree. No production code touched; only documentation files plus two workflow YAMLs whose fallback defaults must match the canonical declaration.
+
+Execution order is driven by dependency (facts first, then canonical owners, then entry-point trimming, then ADR extraction), and all shipped in one commit set so Codex review sees the consolidated state rather than a half-migrated repo.
+
+## Phases
+
+### Phase 1 — Fact sync against code
+
+Pre-read the source-of-truth files and fix all stale factual claims in one pass:
+
+- `src/scripts/harmony.mjs:72-73` → palette `MAX_TOTAL = 15`, `MAX_CHROMATIC = 12`. Propagate to `CLAUDE.md:3`, `AGENTS.md:8`, `docs_pallete_maker/project-idea.md:9`.
+- `index.html:221` → grid `repeat(11, 1fr)` at `≥1280px`. Fix stale `10` in `frontend-docs.md:44`.
+- Repository variable `AI_REVIEW_AGENT=codex` (switched 2026-04-17, spec 008 T008b). Propagate to `AGENTS.md` default policy block, `constitution.md` Roles section, `project-idea.md:28`.
+- Remove phantom references to `docs_pallete_maker/project/devops/macos-local-runners.md` (deleted in spec 006) from `AGENTS.md:109` and `constitution.md:77-84`.
+- Flag Claude review (`claude-review.yml`, `ANTHROPIC_API_KEY`) as "currently non-operational (dead code pending cleanup)" in `review-contract.md` and `ai-orchestration-protocol.md` — do not describe as live.
+
+### Phase 2 — Canonical ownership map
+
+Establish single-source-of-truth files for each previously-duplicated block:
+
+| Fact                             | Canonical owner                   | Other files                                              |
+| -------------------------------- | --------------------------------- | -------------------------------------------------------- |
+| Palette size (15 = 12 + 3)       | `project-idea.md`                 | CLAUDE.md, AGENTS.md keep 1-line inline (hybrid pattern) |
+| Grid columns (3/4/6/8/11)        | `frontend-docs.md`                | Referenced only                                          |
+| Default review backend           | `ai-orchestration-protocol.md`    | Entry points keep 1-line inline                          |
+| Standard Feature Loop (10 steps) | `.specify/memory/constitution.md` | `ai-pr-workflow.md` drops its duplicate, points back     |
+| Bot-trigger rejection rules      | `review-trigger-automation.md`    | `review-contract.md` keeps 2-line summary + link         |
+| OMC mode catalog                 | `CLAUDE.md`                       | `AGENTS.md` keeps one-line pointer                       |
+
+Apply hybrid-reference pattern (`feedback_docs_consolidation_pattern.md`): short facts inline in entry points; long blocks (10+ lines) consolidated to canonical; mid-size (3-10 lines) get a 2-line summary + link in non-canonical locations.
+
+### Phase 3 — Entry-point trimming + reading route unification
+
+- `CLAUDE.md`: add 2 Karpathy-derived directives to "Важные правила"; keep OMC mode details (they are Claude-specific); add `delivery-playbook.md` and `adr/README.md` to the Documentation section; adjust palette fact.
+- `AGENTS.md`: trim rule 7 (OMC block) to a one-liner pointing at CLAUDE.md; update Reading Route to include `review-contract.md`, `review-trigger-automation.md`, `delivery-playbook.md`, `vercel-cd.md`; remove phantom `macos-local-runners.md` from rule 4.
+- `docs_pallete_maker/README.md`: remove "Main reading order" section entirely (replaced by AGENTS.md reference); rewrite Structure into a topical index grouped by Product / Frontend / Delivery & CI / Decisions.
+
+### Phase 4 — Orientability headers in devops docs
+
+Add `> Audience: ... | Prereq: ... | Next: ...` as the first line after the H1 in each of the 6 files under `docs_pallete_maker/project/devops/`. Five minutes per file, immediate navigation clarity.
+
+### Phase 5 — ADR extraction
+
+Create `docs_pallete_maker/adr/0001-review-trigger-design.md` containing Tier 2 (husky post-push hook) and Tier 3 (PAT-based GitHub Actions workflow) designs + PAT security requirements, relocated from `review-trigger-automation.md`. The operational doc keeps only Tier 1 (active) and a pointer to the ADR. Update `adr/README.md` with an index section listing the new ADR.
+
+### Phase 6 — Workflow fallback alignment (reactive to Codex P2 #2)
+
+`.github/workflows/ai-review.yml` line 78 and `ai-command-policy.yml` line 37 use `gemini` as the fallback when `AI_REVIEW_AGENT` is unset. The canonical doc declaration is `codex`. Change both fallbacks to `codex`, and update the explanatory comment in `ai-review.yml` to correctly state that only Gemini auto-reviews on PR open.
+
+### Phase 7 — Verify and ship
+
+- `pnpm run preflight` locally (feature-memory + baseline + html + build + format + tests).
+- Commit, push, open PR with human-authored `@codex review` trigger.
+- Address any Codex P0-P2 findings in subsequent commits on the same branch. P3 findings are advisory-only.
+
+## Risk surface
+
+**R1 — Link-following regression for CI-mode reviewers.** Codex / Gemini in review mode may not reliably follow internal doc links. When consolidating, if a critical fact is only at the canonical location, a reviewer reading a sibling file might answer from training data instead. Mitigation: hybrid-reference pattern. Short facts inline in entry points and near-sibling docs; only long blocks pure-reference.
+
+**R2 — Stack-wide drift after changing a canonical declaration.** Declaring "default = codex" in docs left workflow fallbacks pointing to `gemini`. Codex found this on the first review round. Mitigation: grep the whole repo (workflows, scripts, tests) for the previous default value before claiming stack-wide consistency. Documented in `feedback_canonical_default_stack_audit.md`.
+
+**R3 — Guard feature-memory gate on workflow changes.** `.github/workflows/` counts as product paths per `scripts/check-feature-memory.mjs`, so any workflow change requires a complete `specs/<id>/{spec,plan,tasks}.md` folder — which is this spec.
+
+**R4 — `check-static-baseline.mjs` requires specific devops files.** The baseline check hardcodes `review-contract.md`, `review-trigger-automation.md`, `delivery-playbook.md`, etc. This refactor keeps all of them (trims content, not files), so baseline stays green.
+
+**R5 — Prettier formatting on new markdown.** `docs_pallete_maker/README.md` needed a post-write reformat (blank lines between heading and list). Run `pnpm exec prettier --write` on any edited markdown before the final preflight.
+
+## Rollback plan
+
+All changes live on `claude/silly-margulis-57ff15`. If a regression surfaces post-merge (e.g. a reviewer hallucinates a now-pure-reference fact), revert-merge the PR and retry with more facts kept inline per hybrid-reference pattern. No schema migration, no data loss risk.

--- a/specs/014-docs-2tier-consolidation/spec.md
+++ b/specs/014-docs-2tier-consolidation/spec.md
@@ -1,0 +1,54 @@
+# Spec 014 — Docs 2-tier Consolidation + Fact Sync
+
+## Problem
+
+After 13 PRs of incremental docs growth, agent-facing documentation had accumulated four distinct friction classes that the 2026-04-18 audit (critic + architect subagents on PR #17 preparation) made explicit:
+
+1. **Four competing entry points.** `CLAUDE.md`, `AGENTS.md`, `.specify/memory/constitution.md`, and `docs_pallete_maker/README.md` all claimed "read me first". Agents (Claude, Codex, Gemini) ended up reading the same information 2-3 times in different phrasings with no single source of truth.
+
+2. **Fact drift with 3 simultaneous values.** The palette size appeared as "up to 10" (CLAUDE.md, AGENTS.md), "up to 14 (11 chromatic + 3 achromatic)" (project-idea.md), and "up to 15" (docs_pallete_maker/README.md), while the actual code in `src/scripts/harmony.mjs:72-73` has `MAX_TOTAL = 15, MAX_CHROMATIC = 12`. Grid columns had the same pattern: `11` on line 13 vs `10` on line 44 of `frontend-docs.md`, with `index.html:221` actually using `repeat(11, 1fr)`. This class of drift was already documented as a recurring hallucination source in `feedback_docs_drift_audit.md`.
+
+3. **Stale review-agent policy.** Docs still said "Gemini is the default review backend" everywhere (7 files verbatim) even though the repository switched to `AI_REVIEW_AGENT=codex` on 2026-04-17 (spec 008 T008b). Worse, the workflow fallbacks in `.github/workflows/ai-review.yml` and `ai-command-policy.yml` still defaulted to `gemini` when the variable was unset.
+
+4. **Phantom file references + dead-code paths advertised as operational.** Both `AGENTS.md:109` and `.specify/memory/constitution.md:80` still linked to `docs_pallete_maker/project/devops/macos-local-runners.md`, a file deleted in spec 006. `review-contract.md` and `ai-orchestration-protocol.md` described the Claude review path as a live third-tier option despite the local runner rollback (spec 006) and absent `ANTHROPIC_API_KEY`.
+
+## Goals
+
+- Reduce agent-facing entry points from 4 to 2: `CLAUDE.md` (Claude-specific, OMC modes) and `AGENTS.md` (universal). `constitution.md` and `docs_pallete_maker/README.md` become content / topical-index files, referenced from the entry points rather than competing with them.
+- Establish a canonical-ownership map for every fact that previously lived in 2+ files. Other files reference the canonical source instead of duplicating content. Short (≤1-2 line) facts that are cited on every read — palette size, default review agent — stay inline in entry points to preserve CI-mode reviewer orientability.
+- Actualize every factual claim against the current code: palette size from `src/scripts/harmony.mjs`, grid columns from `index.html`, review default from repository variables, security-header set from `vercel.json`.
+- Remove all phantom references. Mark non-operational paths (Claude review, ANTHROPIC_API_KEY) explicitly as dead code pending a separate cleanup PR, rather than describing them as live.
+- Align `.github/workflows/ai-review.yml` and `ai-command-policy.yml` fallback defaults with the canonical declaration (`review: "codex"` when the variable is unset). Docs and code must not disagree about what the default is.
+- Adopt two Karpathy-derived CLAUDE.md directives (critic-validated delta from `multica-ai/andrej-karpathy-skills`): forbid speculative abstractions for single-use code; require an inline step+verify plan for 3-5-step routine tasks too small for a full spec.
+- Add orientability headers (`> Audience: ... | Prereq: ... | Next: ...`) to all 6 devops docs so agents jumping in cold have one-line navigation cues.
+- Extract the not-adopted Tier 2/3 review-trigger designs out of `review-trigger-automation.md` (operational doc) into a new ADR `docs_pallete_maker/adr/0001-review-trigger-design.md`. The operational doc keeps only the active Tier 1.
+
+## Non-goals
+
+- No product-code changes. `index.html`, `src/`, tests, and `scripts/` app logic are untouched.
+- No deletion of the `claude-review.yml` workflow file itself (tracked in a separate cleanup PR per memory `project_local_claude_runner.md`).
+- No adoption of Tier 2 (husky post-push hook) or Tier 3 (PAT-based automation) for review triggers — only the design is relocated.
+- No new tests. Documentation coverage is verified by `check-static-baseline.mjs` (still passes) and manual review.
+- No CSP tightening, no new security headers — PR #11 set the baseline and remains the canonical source.
+
+## Acceptance criteria
+
+- `CLAUDE.md` and `AGENTS.md` are the only files that claim "start here"; both link forward rather than duplicate long blocks.
+- `docs_pallete_maker/README.md` contains a topical index only (grouped by Product / Frontend / Delivery & CI / Decisions); reading order lives solely in `AGENTS.md § Reading Route`.
+- Every fact with a known canonical owner appears only once; other locations reference it. Concretely: palette size in `project-idea.md`; grid columns in `frontend-docs.md`; review default in `ai-orchestration-protocol.md`; Standard Feature Loop in `constitution.md`; bot-trigger rejection details in `review-trigger-automation.md`; OMC mode catalog in `CLAUDE.md`.
+- `grep -rn "up to 10 colors\|до 10 цветов\|up to 14 colors"` returns only historical specs (no active docs).
+- `grep -rn "macos-local-runners"` in active docs returns zero matches (only historical specs remain).
+- `.github/workflows/ai-review.yml` and `ai-command-policy.yml` fall back to `codex` when `AI_REVIEW_AGENT` is unset.
+- `.github/workflows/ai-review.yml` includes an updated comment noting that only Gemini auto-reviews on PR open; Codex and Claude require a human trigger on every review.
+- `review-contract.md` includes a 2-line summary of bot-trigger rejection with a link to `review-trigger-automation.md` — not full duplication, but not pure reference either (hybrid-reference pattern, `feedback_docs_consolidation_pattern.md`).
+- `CLAUDE.md` "Важные правила" section includes the two Karpathy-derived directives (no speculative abstractions; inline step+verify plan for multi-step tasks).
+- All 6 files under `docs_pallete_maker/project/devops/` start with a `> Audience | Prereq | Next` orientability header.
+- `docs_pallete_maker/adr/0001-review-trigger-design.md` exists and contains the Tier 2 and Tier 3 designs + PAT security requirements extracted from `review-trigger-automation.md`.
+- `docs_pallete_maker/adr/README.md` lists the new ADR in an index section.
+- `pnpm run preflight` passes (feature-memory gate + baseline + html-validate + build + prettier + 59/59 tests).
+- All required PR checks (`baseline-checks`, `guard`, `osv-scan`, `AI Review`) are green.
+- Codex review on the final PR head is green (no remaining P0-P2 findings). P3 findings are advisory-only per `review-contract.md`.
+
+## Expected net delta
+
+Net `-70` lines across `CLAUDE.md`, `AGENTS.md`, constitution, docs/README, 6 devops docs, project-idea, frontend-docs — duplicated blocks consolidated to canonical homes. One new ADR added. Two workflow YAMLs adjusted (single-line constant change each). No production behavior change.

--- a/specs/014-docs-2tier-consolidation/tasks.md
+++ b/specs/014-docs-2tier-consolidation/tasks.md
@@ -1,0 +1,58 @@
+# Tasks 014 — Docs 2-tier Consolidation + Fact Sync
+
+## Phase 1 — Fact sync
+
+- [x] T001: Palette size → `up to 15 (12 chromatic + 3 achromatic)` in `CLAUDE.md:3`, `AGENTS.md:8`, `docs_pallete_maker/project-idea.md:9`.
+- [x] T002: Grid columns → `11 at ≥1280px` in `frontend-docs.md:44` (stale `10` → `11`).
+- [x] T003: Default review backend → `codex` in `AGENTS.md` default-policy block, `constitution.md` Roles, `project-idea.md:28`, `CLAUDE.md:13`.
+- [x] T004: Remove phantom `macos-local-runners.md` references from `AGENTS.md:109` (rule 4) and `constitution.md:77-84`.
+- [x] T005: Flag Claude review path as "currently non-operational (dead code pending cleanup)" in `review-contract.md` and `ai-orchestration-protocol.md`.
+
+## Phase 2 — Canonical ownership
+
+- [x] T006: Palette size canonical in `project-idea.md`; keep 1-line inline in CLAUDE.md and AGENTS.md (hybrid).
+- [x] T007: Grid columns canonical in `frontend-docs.md`; all other refs link.
+- [x] T008: Default review backend canonical in `ai-orchestration-protocol.md`; entry points keep 1-line inline.
+- [x] T009: Standard Feature Loop canonical in `constitution.md`; `ai-pr-workflow.md` drops duplicate and points back.
+- [x] T010: Bot-trigger rejection canonical in `review-trigger-automation.md`; `review-contract.md` keeps 2-line summary + link.
+- [x] T011: OMC mode catalog canonical in `CLAUDE.md`; `AGENTS.md` rule 7 trimmed to one-line pointer.
+
+## Phase 3 — Entry-point trimming + reading route
+
+- [x] T012: Add 2 Karpathy-derived directives to `CLAUDE.md § Важные правила` (no speculative abstractions; inline step+verify plan for multi-step routine tasks).
+- [x] T013: Add `delivery-playbook.md` and `adr/README.md` to `CLAUDE.md § Документация`.
+- [x] T014: Rewrite `docs_pallete_maker/README.md` as a topical index (Product / Frontend / Delivery & CI / Decisions); remove "Main reading order" section.
+- [x] T015: Update `AGENTS.md § Reading Route` to include `review-contract.md`, `review-trigger-automation.md`, `delivery-playbook.md`, `vercel-cd.md`; reference this as canonical reading order.
+
+## Phase 4 — Orientability headers
+
+- [x] T016: Add `> Audience | Prereq | Next` header to `ai-orchestration-protocol.md`.
+- [x] T017: Add orientability header to `ai-pr-workflow.md`.
+- [x] T018: Add orientability header to `review-contract.md`.
+- [x] T019: Add orientability header to `review-trigger-automation.md`.
+- [x] T020: Add orientability header to `delivery-playbook.md`.
+- [x] T021: Add orientability header to `vercel-cd.md`.
+- [x] T022: Add orientability header to `frontend-docs.md`.
+
+## Phase 5 — ADR extraction
+
+- [x] T023: Create `docs_pallete_maker/adr/0001-review-trigger-design.md` with Tier 2/3 designs + PAT security.
+- [x] T024: Trim `review-trigger-automation.md` to Tier 1 (active) + pointer to ADR.
+- [x] T025: Update `docs_pallete_maker/adr/README.md` with Index section listing the new ADR.
+
+## Phase 6 — Workflow fallback alignment
+
+- [x] T026: `.github/workflows/ai-review.yml:78` — change fallback from `selected="gemini"` to `selected="codex"` when `AI_REVIEW_AGENT` is empty.
+- [x] T027: `.github/workflows/ai-review.yml:40` — update header comment from `(and unset default → gemini)` to `(and unset default → codex)`.
+- [x] T028: `.github/workflows/ai-review.yml` — update skip-mode explanatory comment to note that only Gemini auto-reviews on PR open; Codex and Claude require a human trigger on every review.
+- [x] T029: `.github/workflows/ai-command-policy.yml:37` — change `defaults = { implementation: "claude", review: "gemini" }` to `defaults = { implementation: "claude", review: "codex" }`.
+
+## Phase 7 — Verify and ship
+
+- [x] T030: Fix P2 finding from Codex round 1 on `ai-pr-workflow.md` — clarify that Codex requires a human trigger on PR open, not just on synchronize.
+- [x] T031: Reformat `docs_pallete_maker/README.md` with Prettier (blank lines between H2 and list).
+- [x] T032: Run `pnpm run preflight` — feature-memory + baseline + html + build + format + 59/59 tests green.
+- [x] T033: Commit + push + post `@codex review` on the PR with the current head SHA.
+- [ ] T034: Resolve remaining Codex findings on the final head; confirm `AI Review` check SUCCESS on the current head SHA.
+- [ ] T035: Confirm all required checks green (`baseline-checks`, `guard`, `osv-scan`, `AI Review`, `Vercel`).
+- [ ] T036: Human merge after all checks are COMPLETED + SUCCESSFUL (per CLAUDE.md rule: never merge on MERGEABLE/UNSTABLE).


### PR DESCRIPTION
## Summary

- Consolidates docs to 2 entry points (`CLAUDE.md` + `AGENTS.md`); `constitution.md` and `docs_pallete_maker/README.md` become content/index files, not entry points.
- Establishes canonical-ownership map for duplicated facts: palette size → `project-idea.md`; grid columns → `frontend-docs.md`; review policy → `ai-orchestration-protocol.md`; Standard Feature Loop → `constitution.md`; bot-trigger rejection → `review-trigger-automation.md`; OMC modes → `CLAUDE.md`.
- Fact sync against code: palette `up to 15 (12 chromatic + 3 achromatic)` from `harmony.mjs:72-73`; grid `11 cols ≥1280px` from `index.html:221`; default review backend `codex` (switched 2026-04-17); Claude review marked non-operational (dead-code pending cleanup).
- Removes phantom references to deleted `macos-local-runners.md` (AGENTS.md rule 4, constitution.md).
- Adds orientability headers (`> Audience: ... | Prereq: ... | Next: ...`) to all 6 devops docs.
- Extracts non-adopted Tier 2/3 review-trigger design into new `docs_pallete_maker/adr/0001-review-trigger-design.md`; shrinks `review-trigger-automation.md` to active Tier 1 only.
- Adds 2 directives to CLAUDE.md (from Karpathy CLAUDE.md delta, critic-validated): no single-use abstractions; inline step+verify plan for multi-step tasks without a spec.

Net `-70` lines; duplicated blocks consolidated to single canonical homes with cross-references.

## Test plan

- [x] `pnpm run preflight` — feature-memory gate + baseline + html-validate + build + format + 59/59 tests green
- [ ] `baseline-checks`, `guard`, `AI Review` green on PR
- [ ] Codex review on latest push (posted via human-authored `@codex review`)
- [ ] Vercel preview builds cleanly (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)