### PR TITLE
[codex] fix AI Review trusted checkout

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -60,6 +60,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Resolve PR context
         id: pr

--- a/docs_pallete_maker/project/devops/ai-pr-workflow.md
+++ b/docs_pallete_maker/project/devops/ai-pr-workflow.md
@@ -29,6 +29,11 @@ Summary (details in `review-contract.md` and `ai-orchestration-protocol.md`):
 
 - `AI Review` is the normalized required check regardless of the backend.
 - Reviewer selection comes only from `AI_REVIEW_AGENT` (current default: `codex`).
+- Gate-based `AI Review` runs execute repository scripts from
+  `github.event.repository.default_branch`, not from the pull request head. The
+  gate still resolves the PR number and head SHA through GitHub API context, but
+  contributors cannot alter `scripts/ai-review-gate.mjs` in their own PR to
+  change the required-check decision logic.
 - Low-severity-only findings are advisory and non-blocking.
 - **Human trigger required for Codex on EVERY review**, including the first
   review on PR open — Codex does not auto-review. (Only Gemini Code Assist

--- a/scripts/check-static-baseline.mjs
+++ b/scripts/check-static-baseline.mjs
@@ -63,6 +63,10 @@ if (missing.length > 0 || missingDirs.length > 0) {
 }
 
 const html = readFileSync(resolve(root, "index.html"), "utf8");
+const aiReviewWorkflow = readFileSync(
+  resolve(root, ".github/workflows/ai-review.yml"),
+  "utf8",
+);
 
 // Declarative HTML content assertions.
 // Add entries here instead of hardcoding new checks below.
@@ -101,6 +105,34 @@ const htmlAssertions = [
 const failures = htmlAssertions
   .filter(({ test }) => !test(html))
   .map(({ message }) => message);
+
+const workflowAssertions = [
+  {
+    test: (workflow) => {
+      const checkoutStep = workflow.match(
+        /- name: Checkout\s*\n\s*uses: actions\/checkout@[^\n]+\n\s*with:\n(?<withBlock>(?:\s+[a-zA-Z0-9_-]+:\s*[^\n]+\n)+)/,
+      );
+
+      return (
+        checkoutStep?.groups?.withBlock
+          ?.split(/\r?\n/)
+          .some((line) =>
+            /^ref:\s*\$\{\{\s*github\.event\.repository\.default_branch\s*\}\}\s*$/.test(
+              line.trim(),
+            ),
+          ) ?? false
+      );
+    },
+    message:
+      "AI Review checkout must use ref: ${{ github.event.repository.default_branch }} so gate scripts run from trusted main.",
+  },
+];
+
+failures.push(
+  ...workflowAssertions
+    .filter(({ test }) => !test(aiReviewWorkflow))
+    .map(({ message }) => message),
+);
 
 if (failures.length > 0) {
   for (const msg of failures) {

--- a/specs/016-trusted-ai-review-checkout/plan.md
+++ b/specs/016-trusted-ai-review-checkout/plan.md
@@ -1,0 +1,26 @@
+# Plan — 016-trusted-ai-review-checkout
+
+## Approach
+
+1. Update the gate-based `AI Review` checkout step to use
+   `github.event.repository.default_branch`.
+2. Extend `scripts/check-static-baseline.mjs` with a workflow assertion for the
+   trusted checkout ref.
+3. Update the AI PR workflow documentation with the security invariant.
+4. Run focused validation first, then the repository preflight.
+
+## Risk Notes
+
+- `workflow_dispatch` also has `github.event.repository.default_branch`, so the
+  same ref expression works for manual reruns.
+- The trusted checkout changes which copy of the scripts runs, not which pull
+  request is reviewed. `scripts/resolve-pr-context.mjs` continues to resolve the
+  PR number, head SHA, base ref, and head ref from GitHub API context.
+- The fix PR may still fail `AI Review` because the currently required gate is
+  the vulnerable version until this change lands on `main`.
+
+## Done When
+
+- `pnpm run check:repo` passes.
+- `pnpm run preflight` passes locally.
+- Branch is pushed and a draft PR is opened against `main`.

--- a/specs/016-trusted-ai-review-checkout/spec.md
+++ b/specs/016-trusted-ai-review-checkout/spec.md
@@ -1,0 +1,39 @@
+# Spec 016 — Trusted AI Review Gate Checkout
+
+## Problem
+
+The `AI Review` workflow runs gate scripts that decide whether a pull request
+has passed native AI review. On `pull_request` events, an unqualified
+`actions/checkout` can resolve to the PR head. That lets a contributor modify
+the gate script in the same PR and potentially make the required `AI Review`
+check pass with untrusted logic.
+
+Codex already reported this as a P0 in review. This PR closes the repository
+side of that finding by forcing the gate job to execute scripts from the
+repository default branch.
+
+## Goals
+
+- Make the gate-based `AI Review` job checkout
+  `github.event.repository.default_branch`.
+- Preserve the existing PR context resolution and native review polling
+  behavior.
+- Add a repository baseline assertion so the trusted checkout invariant is not
+  accidentally removed later.
+- Document the invariant in durable devops docs.
+
+## Non-goals
+
+- Redesign AI review triggering or skip-mode behavior.
+- Change the selected review backend policy.
+- Make this PR merge-ready despite the expected review gate failure on the fix
+  PR itself.
+
+## Acceptance Criteria
+
+- `.github/workflows/ai-review.yml` checks out
+  `ref: ${{ github.event.repository.default_branch }}` before running
+  `scripts/resolve-pr-context.mjs` and `scripts/ai-review-gate.mjs`.
+- `pnpm run check:repo` fails if the trusted checkout ref is missing.
+- Durable devops docs explain that gate code executes from the trusted default
+  branch while PR metadata still targets the reviewed head SHA.

--- a/specs/016-trusted-ai-review-checkout/tasks.md
+++ b/specs/016-trusted-ai-review-checkout/tasks.md
@@ -1,0 +1,8 @@
+# Tasks — 016-trusted-ai-review-checkout
+
+- [x] Add trusted default-branch ref to the gate-based AI Review checkout.
+- [x] Add baseline assertion for the trusted checkout invariant.
+- [x] Document the invariant in durable devops docs.
+- [x] Run `pnpm run check:repo`.
+- [x] Run `pnpm run preflight`.
+- [ ] Push branch and open draft PR.


### PR DESCRIPTION
## Summary

- force the gate-based AI Review workflow checkout to use `github.event.repository.default_branch` before running gate scripts
- add a baseline assertion that fails if the trusted checkout ref is removed
- record the security invariant in spec 016 and AI PR workflow docs

## Why

The AI Review required check runs `scripts/resolve-pr-context.mjs` and `scripts/ai-review-gate.mjs`. Without an explicit ref, `actions/checkout` on pull request events can execute scripts from the PR head, allowing a contributor to modify the gate logic in the same PR.

## Validation

- `pnpm run check:repo`
- `node scripts/check-feature-memory.mjs --worktree` after staging
- `pnpm run preflight` after commit

## Expected checks

`AI Review` may fail for this fix PR itself because the trusted-checkout repair is not active on `main` until this PR lands. That failure is expected for this security patch.