### PR TITLE
chore(security): assert exactly one checkout step in AI Review

### DIFF
--- a/docs_pallete_maker/project/devops/ai-pr-workflow.md
+++ b/docs_pallete_maker/project/devops/ai-pr-workflow.md
@@ -33,7 +33,11 @@ Summary (details in `review-contract.md` and `ai-orchestration-protocol.md`):
   `github.event.repository.default_branch`, not from the pull request head. The
   gate still resolves the PR number and head SHA through GitHub API context, but
   contributors cannot alter `scripts/ai-review-gate.mjs` in their own PR to
-  change the required-check decision logic.
+  change the required-check decision logic. The workflow must contain exactly
+  one `actions/checkout@...` step — a second checkout would overwrite the
+  trusted scripts. `pnpm run check:repo` enforces both invariants (see
+  `specs/016-trusted-ai-review-checkout/` and
+  `specs/017-defense-in-depth-checkout-assertion/`).
 - Low-severity-only findings are advisory and non-blocking.
 - **Human trigger required for Codex on EVERY review**, including the first
   review on PR open — Codex does not auto-review. (Only Gemini Code Assist

--- a/scripts/check-static-baseline.mjs
+++ b/scripts/check-static-baseline.mjs
@@ -126,6 +126,14 @@ const workflowAssertions = [
     message:
       "AI Review checkout must use ref: ${{ github.event.repository.default_branch }} so gate scripts run from trusted main.",
   },
+  {
+    test: (workflow) => {
+      const matches = workflow.match(/uses:\s*actions\/checkout@/g);
+      return (matches?.length ?? 0) === 1;
+    },
+    message:
+      "AI Review workflow must contain exactly one actions/checkout step. A second checkout could overwrite gate scripts after the trusted default-branch checkout.",
+  },
 ];
 
 failures.push(

--- a/scripts/check-static-baseline.mjs
+++ b/scripts/check-static-baseline.mjs
@@ -131,8 +131,10 @@ const workflowAssertions = [
       // Anchor on line start so YAML comments (`# uses: actions/checkout@...`)
       // and arbitrary text inside `run:` scripts are not counted as steps.
       // Optional leading `-` covers the inline `- uses: ...` step form.
+      // Optional surrounding quote covers double- and single-quoted scalar
+      // values (`uses: "actions/checkout@..."`).
       const matches = workflow.match(
-        /^[ \t]*-?[ \t]*uses:[ \t]*actions\/checkout@/gm,
+        /^[ \t]*-?[ \t]*uses:[ \t]*['"]?actions\/checkout@/gm,
       );
       return (matches?.length ?? 0) === 1;
     },

--- a/scripts/check-static-baseline.mjs
+++ b/scripts/check-static-baseline.mjs
@@ -128,7 +128,12 @@ const workflowAssertions = [
   },
   {
     test: (workflow) => {
-      const matches = workflow.match(/uses:\s*actions\/checkout@/g);
+      // Anchor on line start so YAML comments (`# uses: actions/checkout@...`)
+      // and arbitrary text inside `run:` scripts are not counted as steps.
+      // Optional leading `-` covers the inline `- uses: ...` step form.
+      const matches = workflow.match(
+        /^[ \t]*-?[ \t]*uses:[ \t]*actions\/checkout@/gm,
+      );
       return (matches?.length ?? 0) === 1;
     },
     message:

--- a/specs/017-defense-in-depth-checkout-assertion/plan.md
+++ b/specs/017-defense-in-depth-checkout-assertion/plan.md
@@ -1,0 +1,32 @@
+# Plan — 017-defense-in-depth-checkout-assertion
+
+## Approach
+
+1. Append a second entry to the `workflowAssertions` array in
+   `scripts/check-static-baseline.mjs`. The test counts
+   `uses: actions/checkout@` matches in the workflow file and passes only if
+   the count is exactly 1.
+2. Run `pnpm run check:repo` against current `main` (1 checkout) — must pass.
+3. Run `pnpm run preflight` for the full local gate.
+4. Manually simulate the attack: paste a second `uses: actions/checkout@...`
+   line into `.github/workflows/ai-review.yml` and confirm
+   `pnpm run check:repo` fails with the new message. Revert the change.
+
+## Risk Notes
+
+- This change only adds a static assertion. It cannot affect workflow runtime.
+- The regex `uses:\s*actions\/checkout@` is intentionally loose so it matches
+  pinned SHAs, version tags, and any future `with:` placement. Forks of the
+  third-party `actions/checkout` action would not be caught — that is out of
+  scope.
+- The existing trusted-`ref` assertion still runs first, so a workflow that
+  removes the trusted ref entirely would fail with the spec 016 message,
+  not the new one.
+
+## Done When
+
+- `pnpm run check:repo` passes on the modified branch.
+- Negative case (manual second-checkout simulation) fails `pnpm run check:repo`
+  with the new message and is reverted.
+- `pnpm run preflight` passes locally.
+- Branch is pushed and a PR is opened against `main`.

--- a/specs/017-defense-in-depth-checkout-assertion/plan.md
+++ b/specs/017-defense-in-depth-checkout-assertion/plan.md
@@ -15,10 +15,13 @@
 ## Risk Notes
 
 - This change only adds a static assertion. It cannot affect workflow runtime.
-- The regex anchors on line start (`^[ \t]*-?[ \t]*uses:[ \t]*actions\/checkout@`,
-  `m` flag) so YAML comments (`# uses: actions/checkout@...`) and literal
-  occurrences inside `run:` scripts that begin with `#` are not counted.
-  Optional leading `-` covers the inline `- uses: ...` step form. A literal
+- The regex anchors on line start
+  (`^[ \t]*-?[ \t]*uses:[ \t]*['"]?actions\/checkout@`, `m` flag) so YAML
+  comments (`# uses: actions/checkout@...`) and literal occurrences inside
+  `run:` scripts that begin with `#` are not counted. Optional leading `-`
+  covers the inline `- uses: ...` step form. Optional surrounding quote covers
+  YAML-valid double- and single-quoted scalar values
+  (`uses: "actions/checkout@..."`, `uses: 'actions/checkout@...'`). A literal
   `uses: actions/checkout@` inside a multi-line `run: |` block at column 0
   would still match — accepted as a false positive since no realistic edit to
   `ai-review.yml` writes that.

--- a/specs/017-defense-in-depth-checkout-assertion/plan.md
+++ b/specs/017-defense-in-depth-checkout-assertion/plan.md
@@ -15,10 +15,13 @@
 ## Risk Notes
 
 - This change only adds a static assertion. It cannot affect workflow runtime.
-- The regex `uses:\s*actions\/checkout@` is intentionally loose so it matches
-  pinned SHAs, version tags, and any future `with:` placement. Forks of the
-  third-party `actions/checkout` action would not be caught — that is out of
-  scope.
+- The regex anchors on line start (`^[ \t]*-?[ \t]*uses:[ \t]*actions\/checkout@`,
+  `m` flag) so YAML comments (`# uses: actions/checkout@...`) and literal
+  occurrences inside `run:` scripts that begin with `#` are not counted.
+  Optional leading `-` covers the inline `- uses: ...` step form. A literal
+  `uses: actions/checkout@` inside a multi-line `run: |` block at column 0
+  would still match — accepted as a false positive since no realistic edit to
+  `ai-review.yml` writes that.
 - The existing trusted-`ref` assertion still runs first, so a workflow that
   removes the trusted ref entirely would fail with the spec 016 message,
   not the new one.

--- a/specs/017-defense-in-depth-checkout-assertion/spec.md
+++ b/specs/017-defense-in-depth-checkout-assertion/spec.md
@@ -1,0 +1,44 @@
+# Spec 017 — Defense-in-Depth Checkout Assertion
+
+## Problem
+
+Spec 016 added a baseline assertion that the `AI Review` workflow checks out
+`github.event.repository.default_branch` on its first `Checkout` step. The
+current regex matches the first `- name: Checkout` block and verifies the `ref`
+inside its `with:` body.
+
+Reviewer (Claude critic, session 2026-04-27) raised a non-blocking finding on
+PR #20: the assertion does not catch a scenario where a second
+`actions/checkout` step is added later in the workflow. A second checkout
+without `ref` (or pointed at the PR head) would overwrite the gate scripts
+checked out from the trusted default branch, defeating spec 016.
+
+## Goals
+
+- Extend `scripts/check-static-baseline.mjs` with a second workflow assertion:
+  `.github/workflows/ai-review.yml` must contain exactly one
+  `actions/checkout@...` step.
+- Keep the existing `ref: ${{ github.event.repository.default_branch }}`
+  assertion unchanged.
+- Fail `pnpm run check:repo` (and therefore `pnpm run preflight`, PR Guard, and
+  CI) if a future change introduces a second checkout step in the AI Review
+  workflow.
+
+## Non-goals
+
+- Migrate `check-static-baseline.mjs` to a YAML parser. The declarative regex
+  array stays as-is.
+- Change runtime behavior of the `AI Review` workflow.
+- Introduce new env vars, scripts, or required files.
+
+## Acceptance Criteria
+
+- `scripts/check-static-baseline.mjs` `workflowAssertions` array contains a
+  second entry that asserts exactly one occurrence of
+  `uses: actions/checkout@` in `.github/workflows/ai-review.yml`.
+- `pnpm run check:repo` passes on the current `main` (1 checkout step).
+- Adding a second `actions/checkout` step to `ai-review.yml` causes
+  `pnpm run check:repo` to fail with the documented message about a possible
+  overwrite of gate scripts.
+- Removing or replacing the only checkout step still trips the existing
+  trusted-ref assertion (no regression).

--- a/specs/017-defense-in-depth-checkout-assertion/tasks.md
+++ b/specs/017-defense-in-depth-checkout-assertion/tasks.md
@@ -1,0 +1,11 @@
+# Tasks — 017-defense-in-depth-checkout-assertion
+
+- [x] Append checkout-count assertion to `workflowAssertions` in
+      `scripts/check-static-baseline.mjs`.
+- [x] Run `pnpm run check:repo` — must pass (1 checkout in `ai-review.yml`).
+- [x] Negative-case simulation: temporarily add a second
+      `uses: actions/checkout@...` line and confirm `pnpm run check:repo` fails
+      with the new message; revert.
+- [x] Run `pnpm run preflight` — must pass.
+- [ ] Push branch and open PR against `main`.
+- [ ] Trigger Codex review via `gh pr comment <PR#> --body "@codex review"`.


### PR DESCRIPTION
## Summary

- Adds a second assertion to `scripts/check-static-baseline.mjs` `workflowAssertions`: `.github/workflows/ai-review.yml` must contain exactly **one** `actions/checkout@...` step.
- Closes the gap raised in PR #20 review (Claude critic, non-blocking finding): the existing trusted-`ref` assertion only inspects the first `Checkout` block. A second checkout step added later in the workflow could overwrite gate scripts that came from the trusted default branch.
- Pure static-detector change. Zero runtime impact on the workflow itself.

## Spec triplet

`specs/017-defense-in-depth-checkout-assertion/{spec,plan,tasks}.md`.

## Validation

- `pnpm run preflight` passes on this branch (current `ai-review.yml` has 1 checkout step).
- Negative case verified locally: temporarily inserting a second `uses: actions/checkout@...` step into `ai-review.yml` makes `pnpm run check:repo` fail with:

  > `AI Review workflow must contain exactly one actions/checkout step. A second checkout could overwrite gate scripts after the trusted default-branch checkout.`

  Reverted before commit.

## Test plan

- [ ] CI green on `feat/checkout-defense-assertion`.
- [ ] PR Guard green.
- [ ] AI Review (`@codex review`) reports no new findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)