### PR TITLE
docs: use @ syntax for CLAUDE.md doc references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,9 +59,9 @@
 
 ## Документация
 
-- Конституция процесса: `.specify/memory/constitution.md`
-- Карта docs: `docs_pallete_maker/README.md`
-- Идея проекта: `docs_pallete_maker/project-idea.md`
+- Конституция процесса: @.specify/memory/constitution.md
+- Карта docs: @docs_pallete_maker/README.md
+- Идея проекта: @docs_pallete_maker/project-idea.md
 - Frontend: `docs_pallete_maker/project/frontend/frontend-docs.md`
 - Orchestration: `docs_pallete_maker/project/devops/ai-orchestration-protocol.md`
 - PR loop: `docs_pallete_maker/project/devops/ai-pr-workflow.md`


### PR DESCRIPTION
## Summary
- Convert top documentation references in CLAUDE.md to `@` syntax (constitution, docs map, project idea)
- `@path` makes Claude Code auto-load file content at session start

## Why
Per Anthropic recommendation. Plain backtick paths require an explicit Read tool call.

## Scope
Only top 3 most critical paths in the Documentation section. The rest remain as backticks (still findable as an index).

## Test plan
- [ ] baseline-checks + guard + AI Review pass
- [ ] No broken paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)