### PR TITLE
chore(dependabot): group minor and patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,9 +16,11 @@ updates:
       include: "scope"
     cooldown:
       default-days: 7
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 3
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "npm"
     directory: "/"
@@ -39,3 +41,8 @@ updates:
       semver-major-days: 14
       semver-minor-days: 7
       semver-patch-days: 3
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/docs_pallete_maker/project/devops/vercel-cd.md
+++ b/docs_pallete_maker/project/devops/vercel-cd.md
@@ -70,8 +70,10 @@ is a future improvement.
   Google's Open Source Vulnerabilities database and fails the check on any
   known CVE. Broader coverage than `npm audit`.
 - **Dependabot** (`.github/dependabot.yml`) opens weekly update PRs for
-  `github-actions` and `npm` ecosystems with a 7-day cooldown on new
-  releases (14 days for major bumps, 3 for patches). The cooldown protects
+  `github-actions` and `npm` ecosystems with a 7-day default cooldown on new
+  releases. The `npm` ecosystem additionally uses 14 days for major bumps and
+  3 days for patches; `github-actions` uses only the default cooldown.
+  Minor and patch updates are grouped per ecosystem. The cooldown protects
   against freshly compromised releases.
 - **Pinned action SHAs.** Third-party GitHub Actions are pinned to a
   commit SHA with a trailing `# v<tag>` comment. Currently pinned:

--- a/specs/008-security-hardening/spec.md
+++ b/specs/008-security-hardening/spec.md
@@ -29,7 +29,7 @@ The vibecode.morecil.ru/ru wiki review (2026-04-17) surfaced OSV Scanner, SHA-pi
 
 - `vercel.json` declares `Content-Security-Policy`, `Strict-Transport-Security`, `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy` for `/(.*)`.
 - `.github/workflows/osv-scan.yml` present, triggers on `pull_request`, `push` to `main`, weekly cron, and `workflow_dispatch`; uses pinned SHA for `google/osv-scanner-action`.
-- `.github/dependabot.yml` configures `github-actions` and `npm` with weekly interval and cooldown (default 7, major 14, minor 7, patch 3 days).
+- `.github/dependabot.yml` configures `github-actions` and `npm` with a weekly interval and a 7-day default cooldown; `npm` additionally uses 14 days for major, 7 for minor, and 3 for patch updates, while `github-actions` uses the default cooldown only. Minor and patch updates are grouped per ecosystem.
 - `anthropics/claude-code-action` pinned to SHA in `claude-agent.yml` and `claude-review.yml`.
 - `docs_pallete_maker/project/devops/vercel-cd.md` documents headers and supply-chain hygiene.
 - All existing checks pass: `pnpm run ci`, PR Guard (docs coverage + feature memory), OSV Scan, AI Review.


### PR DESCRIPTION
## Summary

- remove unsupported `semver-*-days` cooldown settings from the `github-actions` ecosystem
- keep the GitHub Actions default cooldown and group minor and patch updates for each configured ecosystem

## Why

Dependabot does not support semver-specific cooldown settings for GitHub Actions. Grouping minor and patch updates reduces routine PR churn without changing dependency versions now.

## Validation

- YAML parsing
- `pnpm exec prettier --check .github/dependabot.yml`
- `pnpm run check:repo`

Co-authored-by: Codex <codex@openai.com>